### PR TITLE
odim 3617:adding the stub connection methods in config 

### DIFF
--- a/lib-utilities/config/mockconfig.go
+++ b/lib-utilities/config/mockconfig.go
@@ -253,6 +253,16 @@ func SetUpMockConfig(t *testing.T) error {
 		},
 	}
 	Data.SupportedPluginTypes = []string{"Compute", "Fabric"}
+	Data.ConnectionMethodConf = []ConnectionMethodConf{
+		{
+			ConnectionMethodType:    "Redfish",
+			ConnectionMethodVariant: "Compute:BasicAuth:GRF:1.0.0",
+		},
+		{
+			ConnectionMethodType:    "Redfish",
+			ConnectionMethodVariant: "Storage:BasicAuth:STG:1.0.0",
+		},
+	}
 	SetVerifyPeer(Data.TLSConf.VerifyPeer)
 	SetTLSMinVersion(Data.TLSConf.MinVersion)
 	SetTLSMaxVersion(Data.TLSConf.MaxVersion)

--- a/lib-utilities/config/mockconfig_test.go
+++ b/lib-utilities/config/mockconfig_test.go
@@ -76,4 +76,7 @@ func TestSetUpMockConfig(t *testing.T) {
 	if len(Data.SupportedPluginTypes) == 0 {
 		t.Error("error: Data.SupportedPluginTypes is not initialized")
 	}
+	if len(Data.ConnectionMethodConf) == 0 {
+		t.Error("error: Data.ConnectionMethodConf is not initialized")
+	}
 }


### PR DESCRIPTION
 As part of this task   `Add stub connection method in the mock config of lib-utilities` of #173 is completed 