### PR TITLE
Odim 241:Updating the go.mod reference with latest message bus and edit config.sh for accepting multiple kafka servers

### DIFF
--- a/build/RFPlugin/edit_config.sh
+++ b/build/RFPlugin/edit_config.sh
@@ -35,7 +35,7 @@ sed -i "s#\"LBPort\".*#\"LBPort\": \"45002\"#" /etc/plugin_config/config_redfish
 sed -i "s#\"MessageQueueConfigFilePath\".*#\"MessageQueueConfigFilePath\": \"/etc/plugin_config/platformconfig.toml\",#" /etc/plugin_config/config_redfish_plugin.json
 
 ########changes in platformconfig.toml file ######
-sed -i "s#.*KServers.*#KServers      = \"kafka\"#" /etc/plugin_config/platformconfig.toml
+sed -i "s#.*KServersInfo.*#KServersInfo      = [\"kafka:9092\"]#" /etc/plugin_config/platformconfig.toml
 sed -i "s#.*KAFKACertFile.*#KAFKACertFile      = \"$t/odimra_kafka_client.crt\"#" /etc/plugin_config/platformconfig.toml
 sed -i "s#.*KAFKAKeyFile.*#KAFKAKeyFile      = \"$t/odimra_kafka_client.key\"#" /etc/plugin_config/platformconfig.toml
 sed -i "s#.*KAFKACAFile.*#KAFKACAFile      = \"$t/rootCA.crt\"#" /etc/plugin_config/platformconfig.toml

--- a/build/odimra/edit_config.sh
+++ b/build/odimra/edit_config.sh
@@ -39,7 +39,7 @@ sed -i "s#\"PrivateKeyPath\".*#\"PrivateKeyPath\": \"$c/odimra_server.key\",#" /
 sed -i "s#\"CertificatePath\".*#\"CertificatePath\": \"$c/odimra_server.crt\"#" /etc/odimra_config/odimra_config.json
 
 ########changes in platformconfig.toml file ######
-sed -i "s#.*KServers.*#KServers      = \"kafka\"#" /etc/odimra_config/platformconfig.toml
+sed -i "s#.*KServersInfo.*#KServersInfo      = [\"kafka:9092\"]#" /etc/odimra_config/platformconfig.toml
 sed -i "s#.*KAFKACertFile.*#KAFKACertFile      = \"$c/odimra_kafka_client.crt\"#" /etc/odimra_config/platformconfig.toml
 sed -i "s#.*KAFKAKeyFile.*#KAFKAKeyFile      = \"$c/odimra_kafka_client.key\"#" /etc/odimra_config/platformconfig.toml
 sed -i "s#.*KAFKACAFile.*#KAFKACAFile      = \"$c/rootCA.crt\"#" /etc/odimra_config/platformconfig.toml

--- a/lib-messagebus/platforms/platformconfig.toml
+++ b/lib-messagebus/platforms/platformconfig.toml
@@ -20,7 +20,8 @@
 # with-in odimra for their configuration file handling in the future for uniform
 # configuration management.
 
-#KServersInfo defines the list of Kafka Server URI/Nodename:port. Example: KServersInfo = ["localhost:9092"].
+[KAFKA]
+#Defines the list of Kafka Server URI/Nodename:port. Example: ["localhost:9092"].
 KServersInfo   = [""]
 # Timeout of KAFKA Server connection drop / Keepalive.
 KTimeout   = 10

--- a/lib-messagebus/platforms/platformconfig.toml
+++ b/lib-messagebus/platforms/platformconfig.toml
@@ -20,11 +20,8 @@
 # with-in odimra for their configuration file handling in the future for uniform
 # configuration management.
 
-[KAFKA]
-# Kafka Server List.
-KServers   = ""
-# Listening port.
-KLPort     = 9092
+#KServersInfo defines the list of Kafka Server URI/Nodename:port. Example: KServersInfo = ["localhost:9092"].
+KServersInfo   = [""]
 # Timeout of KAFKA Server connection drop / Keepalive.
 KTimeout   = 10
 # TLS Configuration Data

--- a/plugin-redfish/go.mod
+++ b/plugin-redfish/go.mod
@@ -3,7 +3,7 @@ module github.com/ODIM-Project/ODIM/plugin-redfish
 go 1.13
 
 require (
-	github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20200727133207-df3dfb728bd1
+	github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20201123035446-a964157899a1
 	github.com/ODIM-Project/ODIM/lib-utilities v0.0.0-20201015111324-83393fdedb82
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/google/uuid v1.1.2-0.20200519141726-cb32006e483f

--- a/plugin-redfish/go.sum
+++ b/plugin-redfish/go.sum
@@ -30,6 +30,8 @@ github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXn
 github.com/ODIM-Project/ODIM v0.0.0-20200727133207-df3dfb728bd1 h1:xHtMCjvEgospVT6Wr+OQETcLWMechvuySlZf+UsCmQo=
 github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20200727133207-df3dfb728bd1 h1:8pT0M0eydoMENdhvahO4rFrNMjMbkSuQUJS1j4h6zNQ=
 github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20200727133207-df3dfb728bd1/go.mod h1:SFgC2w23lU3/pQv9ROS3x7iLWQESf4jafMumH/IVS0E=
+github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20201123035446-a964157899a1 h1:dg/t1iHn1VPrFSsDYAjWf2sjcb1w1dmODMedcyrDFVg=
+github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20201123035446-a964157899a1/go.mod h1:SFgC2w23lU3/pQv9ROS3x7iLWQESf4jafMumH/IVS0E=
 github.com/ODIM-Project/ODIM/lib-persistence-manager v0.0.0-20200727095517-f2a4bd1bdef7 h1:J58RfJlekckvgdmdkEydb4givP/2MGPYFKO3uv7LtU4=
 github.com/ODIM-Project/ODIM/lib-persistence-manager v0.0.0-20200727095517-f2a4bd1bdef7/go.mod h1:NyEEh6a2bgEXock1ThrXDLnp2A5syxleqSGmWwucPPA=
 github.com/ODIM-Project/ODIM/lib-persistence-manager v0.0.0-20201005194902-ed323c41b4d6 h1:+Ex1pdY+VB6mXoJRQPV6MXks/M6+AbAiccAAjCrq2Ks=

--- a/svc-aggregation/go.mod
+++ b/svc-aggregation/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/ODIM-Project/ODIM/lib-dmtf v0.0.0-20200727115727-33d557ff397c
-	github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20201007090649-06a4c52ce4cf
+	github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20201123035446-a964157899a1
 	github.com/ODIM-Project/ODIM/lib-persistence-manager v0.0.0-20201021053518-88345d4a9988 // indirect
 	github.com/ODIM-Project/ODIM/lib-rest-client v0.0.0-20201007090649-06a4c52ce4cf
 	github.com/ODIM-Project/ODIM/lib-utilities v0.0.0-20201016064732-c652b5935f93

--- a/svc-aggregation/go.sum
+++ b/svc-aggregation/go.sum
@@ -33,6 +33,8 @@ github.com/ODIM-Project/ODIM/lib-dmtf v0.0.0-20200727115727-33d557ff397c h1:u3+u
 github.com/ODIM-Project/ODIM/lib-dmtf v0.0.0-20200727115727-33d557ff397c/go.mod h1:6TGYR8Sq3/MJid434DXHhA3SX9/sOHwi3114WeFNKsY=
 github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20201007090649-06a4c52ce4cf h1:1LNokQsk+B7+H6JML+kLqNTqqe2QXN0Ae70TBNN57kk=
 github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20201007090649-06a4c52ce4cf/go.mod h1:SFgC2w23lU3/pQv9ROS3x7iLWQESf4jafMumH/IVS0E=
+github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20201123035446-a964157899a1 h1:dg/t1iHn1VPrFSsDYAjWf2sjcb1w1dmODMedcyrDFVg=
+github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20201123035446-a964157899a1/go.mod h1:SFgC2w23lU3/pQv9ROS3x7iLWQESf4jafMumH/IVS0E=
 github.com/ODIM-Project/ODIM/lib-persistence-manager v0.0.0-20200727095517-f2a4bd1bdef7 h1:J58RfJlekckvgdmdkEydb4givP/2MGPYFKO3uv7LtU4=
 github.com/ODIM-Project/ODIM/lib-persistence-manager v0.0.0-20200727095517-f2a4bd1bdef7/go.mod h1:NyEEh6a2bgEXock1ThrXDLnp2A5syxleqSGmWwucPPA=
 github.com/ODIM-Project/ODIM/lib-persistence-manager v0.0.0-20201005194902-ed323c41b4d6/go.mod h1:px22wynjWTLxeeCGenVKhZ0Y+fIJc2RQusZazSo+OsI=

--- a/svc-events/go.mod
+++ b/svc-events/go.mod
@@ -3,7 +3,7 @@ module github.com/ODIM-Project/ODIM/svc-events
 go 1.13
 
 require (
-	github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20200727133207-df3dfb728bd1
+	github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20201123035446-a964157899a1
 	github.com/ODIM-Project/ODIM/lib-persistence-manager v0.0.0-20201021053518-88345d4a9988 // indirect
 	github.com/ODIM-Project/ODIM/lib-rest-client v0.0.0-20201007090649-06a4c52ce4cf
 	github.com/ODIM-Project/ODIM/lib-utilities v0.0.0-20201015111324-83393fdedb82

--- a/svc-events/go.sum
+++ b/svc-events/go.sum
@@ -31,6 +31,8 @@ github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jB
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20200727133207-df3dfb728bd1 h1:8pT0M0eydoMENdhvahO4rFrNMjMbkSuQUJS1j4h6zNQ=
 github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20200727133207-df3dfb728bd1/go.mod h1:SFgC2w23lU3/pQv9ROS3x7iLWQESf4jafMumH/IVS0E=
+github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20201123035446-a964157899a1 h1:dg/t1iHn1VPrFSsDYAjWf2sjcb1w1dmODMedcyrDFVg=
+github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20201123035446-a964157899a1/go.mod h1:SFgC2w23lU3/pQv9ROS3x7iLWQESf4jafMumH/IVS0E=
 github.com/ODIM-Project/ODIM/lib-persistence-manager v0.0.0-20200727095517-f2a4bd1bdef7 h1:J58RfJlekckvgdmdkEydb4givP/2MGPYFKO3uv7LtU4=
 github.com/ODIM-Project/ODIM/lib-persistence-manager v0.0.0-20200727095517-f2a4bd1bdef7/go.mod h1:NyEEh6a2bgEXock1ThrXDLnp2A5syxleqSGmWwucPPA=
 github.com/ODIM-Project/ODIM/lib-persistence-manager v0.0.0-20201005194902-ed323c41b4d6/go.mod h1:px22wynjWTLxeeCGenVKhZ0Y+fIJc2RQusZazSo+OsI=

--- a/svc-task/go.mod
+++ b/svc-task/go.mod
@@ -3,7 +3,7 @@ module github.com/ODIM-Project/ODIM/svc-task
 go 1.13
 
 require (
-	github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20200727133207-df3dfb728bd1
+	github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20201123035446-a964157899a1
 	github.com/ODIM-Project/ODIM/lib-persistence-manager v0.0.0-20201021053518-88345d4a9988 // indirect
 	github.com/ODIM-Project/ODIM/lib-utilities v0.0.0-20201015111324-83393fdedb82
 	github.com/RediSearch/redisearch-go v1.0.1

--- a/svc-task/go.sum
+++ b/svc-task/go.sum
@@ -29,6 +29,8 @@ github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jB
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20200727133207-df3dfb728bd1 h1:8pT0M0eydoMENdhvahO4rFrNMjMbkSuQUJS1j4h6zNQ=
 github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20200727133207-df3dfb728bd1/go.mod h1:SFgC2w23lU3/pQv9ROS3x7iLWQESf4jafMumH/IVS0E=
+github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20201123035446-a964157899a1 h1:dg/t1iHn1VPrFSsDYAjWf2sjcb1w1dmODMedcyrDFVg=
+github.com/ODIM-Project/ODIM/lib-messagebus v0.0.0-20201123035446-a964157899a1/go.mod h1:SFgC2w23lU3/pQv9ROS3x7iLWQESf4jafMumH/IVS0E=
 github.com/ODIM-Project/ODIM/lib-persistence-manager v0.0.0-20200727095517-f2a4bd1bdef7/go.mod h1:NyEEh6a2bgEXock1ThrXDLnp2A5syxleqSGmWwucPPA=
 github.com/ODIM-Project/ODIM/lib-persistence-manager v0.0.0-20201005194902-ed323c41b4d6/go.mod h1:px22wynjWTLxeeCGenVKhZ0Y+fIJc2RQusZazSo+OsI=
 github.com/ODIM-Project/ODIM/lib-persistence-manager v0.0.0-20201012075046-3c059402892a h1:yYO7jsTIL6BFJQYsoZln68F0nySeTHkM3AKwvcQK1/g=


### PR DESCRIPTION
As part of this pr changes related   `Update the lastest references of the lib-message-bus in ODIM services(svc-aggregation,svc-task and svc-event) and plugin-redfish`  and  `Update the docker-compose to populate platform config.toml with lastest configuration format ` tasks are completed for #241 