### PR TITLE
ODIM 281: Changed error response status code for GET operation on invalid event subscription ID

### DIFF
--- a/svc-events/events/getevtsubscription.go
+++ b/svc-events/events/getevtsubscription.go
@@ -62,7 +62,7 @@ func (p *PluginContact) GetEventSubscriptionsDetails(req *eventsproto.EventReque
 	if len(subscriptionDetails) < 1 {
 		log.Printf("Subscription details not found for ID: %v", req.EventSubscriptionID)
 		errorMessage := fmt.Sprintf("Subscription details not found for ID: %v", req.EventSubscriptionID)
-		return common.GeneralError(http.StatusBadRequest, response.ResourceNotFound, errorMessage, []interface{}{"EventSubscription", req.EventSubscriptionID}, nil)
+		return common.GeneralError(http.StatusNotFound, response.ResourceNotFound, errorMessage, []interface{}{"EventSubscription", req.EventSubscriptionID}, nil)
 	}
 
 	for _, evtSubscription := range subscriptionDetails {

--- a/svc-events/events/getevtsubscription_test.go
+++ b/svc-events/events/getevtsubscription_test.go
@@ -105,6 +105,6 @@ func TestGetEventSubscription(t *testing.T) {
 
 	common.TruncateDB(common.OnDisk)
 	resp = pc.GetEventSubscriptionsDetails(req)
-	assert.Equal(t, http.StatusBadRequest, int(resp.StatusCode), "Status Code should be StatusBadRequest")
+	assert.Equal(t, http.StatusNotFound, int(resp.StatusCode), "Status Code should be StatusNotFound")
 
 }


### PR DESCRIPTION
Changes done as part of this PR:
- changed error response for GET operation on invalid event subscription ID, from 400 to 404 
- changed unit test according to the corrected error response
resolves #281