### PR TITLE
ODIM  227 : svc-events:evtsubscription: failing if port number specified. 

### DIFF
--- a/svc-events/events/deletesubscription.go
+++ b/svc-events/events/deletesubscription.go
@@ -57,12 +57,20 @@ func (p *PluginContact) DeleteEventSubscriptions(req *eventsproto.EventRequest) 
 		evcommon.GenErrorResponse(errorMessage, response.ResourceNotFound, http.StatusBadRequest, msgArgs, &resp)
 		return resp
 	}
-	subscriptionDetails, err := evmodel.GetEvtSubscriptions(target.ManagerAddress)
+	addr, errorMessage := getIPFromHostName(target.ManagerAddress)
+	if errorMessage != "" {
+		msgArgs := []interface{}{"Host", target.ManagerAddress}
+		evcommon.GenErrorResponse(errorMessage, response.ResourceNotFound, http.StatusNotFound, msgArgs, &resp)
+		log.Error(errorMessage)
+		return resp
+	}
+	deviceIPAddress := fmt.Sprintf("%v", addr[0])
+	subscriptionDetails, err := evmodel.GetEvtSubscriptions(deviceIPAddress)
 	if err != nil && !strings.Contains(err.Error(), "No data found for the key") {
 		log.Error("error while getting event subscription details : " + err.Error())
 		errorMessage := err.Error()
 		msgArgs := []interface{}{"Host", target.ManagerAddress}
-		evcommon.GenErrorResponse(errorMessage, response.ResourceNotFound, http.StatusBadRequest, msgArgs, &resp)
+		evcommon.GenErrorResponse(errorMessage, response.ResourceNotFound, http.StatusNotFound, msgArgs, &resp)
 		return resp
 	}
 	if len(subscriptionDetails) < 1 {
@@ -94,7 +102,7 @@ func (p *PluginContact) DeleteEventSubscriptions(req *eventsproto.EventRequest) 
 		return resp
 	}
 
-	deviceSubscription, err := evmodel.GetDeviceSubscriptions(target.ManagerAddress)
+	deviceSubscription, err := evmodel.GetDeviceSubscriptions(deviceIPAddress)
 	if err != nil {
 		errorMessage := "Error while get subscription details of device : " + err.Error()
 		msgArgs := []interface{}{"Host", target.ManagerAddress}
@@ -419,7 +427,15 @@ func (p *PluginContact) subscribe(subscriptionPost evmodel.EvtSubPost, origin st
 		return err
 	}
 	// Update Location to all destination of device if already subscribed to the device
-	devSub, err := evmodel.GetDeviceSubscriptions(target.ManagerAddress)
+	var resp response.RPC
+	addr, errorMessage := getIPFromHostName(target.ManagerAddress)
+	if errorMessage != "" {
+		msgArgs := []interface{}{"Host", target.ManagerAddress}
+		evcommon.GenErrorResponse(errorMessage, response.ResourceNotFound, http.StatusNotFound, msgArgs, &resp)
+		log.Error(errorMessage)
+	}
+	deviceIPAddress := fmt.Sprintf("%v", addr[0])
+	devSub, err := evmodel.GetDeviceSubscriptions(deviceIPAddress)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
As part of this PR below changes are done and issue: https://github.com/ODIM-Project/ODIM/issues/227 is addressed 
1.  Logic to handle fqdn with port as hostname while subscribing to event by splitting Fqdn and Port.
2.  Added changes in eventsubscription.go and deletesubscription.go files
3.  Added test case in svc-events

resolves: https://github.com/ODIM-Project/ODIM/issues/227