### PR TITLE
issue-352 : Perform case insensitive match for IS_CONSUL_CLUSTER

### DIFF
--- a/install/Docker/dockerfiles/scripts/consul-entrypoint.sh
+++ b/install/Docker/dockerfiles/scripts/consul-entrypoint.sh
@@ -14,7 +14,7 @@ set -e
 # If deployment type is HA mode, need to add the other consul instances
 # to form the quorum
 
-if [ -n "$IS_CONSUL_CLUSTER" ]; then
+if [[ ${IS_CONSUL_CLUSTER,,} == true ]]; then
 	OLDIFS=$OIFS
 	IFS=','
 	members=($CONSUL_CLUSTER_MEMBERS)

--- a/install/Docker/dockerfiles/scripts/consul-entrypoint.sh
+++ b/install/Docker/dockerfiles/scripts/consul-entrypoint.sh
@@ -13,7 +13,6 @@ set -e
 
 # If deployment type is HA mode, need to add the other consul instances
 # to form the quorum
-
 if [[ ${IS_CONSUL_CLUSTER,,} == true ]]; then
 	OLDIFS=$OIFS
 	IFS=','


### PR DESCRIPTION
Consul entry point script used for starting consul service in container checks if IS_CONSUL_CLUSTER is set to enable consul cluster, which should be case insensitive match of the value.