### PR TITLE
issue-375 : monitor and exit when odim-ra process is not running

### DIFF
--- a/install/Docker/dockerfiles/scripts/consul-entrypoint.sh
+++ b/install/Docker/dockerfiles/scripts/consul-entrypoint.sh
@@ -14,7 +14,7 @@ set -e
 # If deployment type is HA mode, need to add the other consul instances
 # to form the quorum
 
-if [ -n "$IS_CONSUL_CLUSTER" ]; then
+if [[ ${IS_CONSUL_CLUSTER,,} == true ]]; then
 	OLDIFS=$OIFS
 	IFS=','
 	members=($CONSUL_CLUSTER_MEMBERS)

--- a/install/Docker/dockerfiles/scripts/start_account_session.sh
+++ b/install/Docker/dockerfiles/scripts/start_account_session.sh
@@ -14,12 +14,12 @@
 # under the License.
 
 declare PID=0
+declare OWN_PID=$$
 
 sigterm_handler()
 {
         if [[ $PID -ne 0 ]]; then
-                # will wait for other instances to gracefully announce quorum exit
-                sleep 5
+                sleep 1
                 kill -9 $PID
                 wait "$PID" 2>/dev/null
         fi
@@ -40,25 +40,27 @@ run_forever()
 
 start_account_session()
 {
-	cd /bin
-	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
 	registry_address="consul:8500"
-	if [ $HA_ENABLED == true ]; then
+	if [[ ${HA_ENABLED,,} == true ]]; then
 		registry_address="[consul1:8500,consul2:8500,consul3:8500]"
 	fi
-	nohup ./svc-account-session --registry=consul --registry_address=${registry_address} --server_address=account-session:45101 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/account_session.log 2>&1 &
+
+	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
+	nohup /bin/svc-account-session --registry=consul --registry_address=${registry_address} --server_address=account-session:45101 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/account_session.log 2>&1 &
 	PID=$!
-	sleep 2s 
-	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/add-hosts.log 2>&1 &
+	sleep 3
+
+	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/account-session-add-hosts.log 2>&1 &
 }
 
 monitor_process()
 {
         while true; do
-                pid=$(pgrep svc-account-session 2> /dev/null)
-                if [[ $pid -eq 0 ]]; then
+                pid=$(pgrep -fc svc-account-session 2> /dev/null)
+                if [[ $? -ne 0 ]] || [[ $pid -gt 1 ]]; then
                         echo "svc-account-session has exited"
-                        exit 1
+			kill -15 ${OWN_PID}
+			exit 1
                 fi
                 sleep 5
         done &

--- a/install/Docker/dockerfiles/scripts/start_aggregation.sh
+++ b/install/Docker/dockerfiles/scripts/start_aggregation.sh
@@ -14,12 +14,12 @@
 # under the License.
 
 declare PID=0
+declare OWN_PID=$$
 
 sigterm_handler()
 {
         if [[ $PID -ne 0 ]]; then
-                # will wait for other instances to gracefully announce quorum exit
-                sleep 5
+                sleep 1
                 kill -9 $PID
                 wait "$PID" 2>/dev/null
         fi
@@ -40,24 +40,26 @@ run_forever()
 
 start_aggregation()
 {
-	cd /bin
-	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
         registry_address="consul:8500"
-        if [ $HA_ENABLED == true ]; then
+        if [[ ${HA_ENABLED,,} == true ]]; then
                 registry_address="[consul1:8500,consul2:8500,consul3:8500]"
         fi
-	nohup ./svc-aggregation --registry=consul --registry_address=${registry_address} --server_address=aggregation:45102 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/aggregation.log 2>&1 &
+
+	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
+	nohup /bin/svc-aggregation --registry=consul --registry_address=${registry_address} --server_address=aggregation:45102 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/aggregation.log 2>&1 &
 	PID=$!
-	sleep 2s
-  	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/add-hosts.log 2>&1 &
+	sleep 3
+
+	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/aggregation-add-hosts.log 2>&1 &
 }
 
 monitor_process()
 {
         while true; do
-                pid=$(pgrep svc-aggregation 2> /dev/null)
-                if [[ $pid -eq 0 ]]; then
+                pid=$(pgrep -fc svc-aggregation 2> /dev/null)
+                if [[ $? -ne 0 ]] || [[ $pid -gt 1 ]]; then
                         echo "svc-aggregation has exited"
+			kill -15 ${OWN_PID}
                         exit 1
                 fi
                 sleep 5

--- a/install/Docker/dockerfiles/scripts/start_api.sh
+++ b/install/Docker/dockerfiles/scripts/start_api.sh
@@ -14,12 +14,12 @@
 # under the License.
 
 declare PID=0
+declare OWN_PID=$$
 
 sigterm_handler()
 {
 	if [[ $PID -ne 0 ]]; then
-		# will wait for other instances to gracefully announce quorum exit
-		sleep 5
+		sleep 1
 		kill -9 $PID
     		wait "$PID" 2>/dev/null
   	fi
@@ -40,24 +40,26 @@ run_forever()
 
 start_api()
 {
-	cd /bin
-	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
         registry_address="consul:8500"
-        if [ $HA_ENABLED == true ]; then
+        if [[ ${HA_ENABLED,,} == true ]]; then
                 registry_address="[consul1:8500,consul2:8500,consul3:8500]"
         fi
-	nohup ./svc-api --registry=consul --registry_address=${registry_address} --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/api.log 2>&1 &
+
+	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
+	nohup /bin/svc-api --registry=consul --registry_address=${registry_address} --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/api.log 2>&1 &
 	PID=$!
-	sleep 2s
-  	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/add-hosts.log 2>&1 &
+	sleep 3
+
+	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/api-add-hosts.log 2>&1 &
 }
 
 monitor_process()
 {
         while true; do
-                pid=$(pgrep svc-api 2> /dev/null)
-                if [[ $pid -eq 0 ]]; then
+                pid=$(pgrep -fc svc-api 2> /dev/null)
+                if [[ $? -ne 0 ]] || [[ $pid -gt 1 ]]; then
                         echo "svc-api has exited"
+			kill -15 ${OWN_PID}
                         exit 1
                 fi
                 sleep 5

--- a/install/Docker/dockerfiles/scripts/start_events.sh
+++ b/install/Docker/dockerfiles/scripts/start_events.sh
@@ -14,12 +14,12 @@
 # under the License.
 
 declare PID=0
+declare OWN_PID=$$
 
 sigterm_handler()
 {
         if [[ $PID -ne 0 ]]; then
-                # will wait for other instances to gracefully announce quorum exit
-                sleep 5
+                sleep 1
                 kill -9 $PID
                 wait "$PID" 2>/dev/null
         fi
@@ -40,24 +40,26 @@ run_forever()
 
 start_event()
 {
-	cd /bin
-	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
         registry_address="consul:8500"
-        if [ $HA_ENABLED == true ]; then
+        if [[ ${HA_ENABLED,,} == true ]]; then
                 registry_address="[consul1:8500,consul2:8500,consul3:8500]"
         fi
-	nohup ./svc-events --registry=consul --registry_address=${registry_address} --server_address=event:45103 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/event.log 2>&1 &
+
+	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
+	nohup /bin/svc-events --registry=consul --registry_address=${registry_address} --server_address=event:45103 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/event.log 2>&1 &
 	PID=$!
-	sleep 2s
-  	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/add-hosts.log 2>&1 &
+	sleep 3
+
+	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/event-add-hosts.log 2>&1 &
 }
 
 monitor_process()
 {
 	while true; do
-		pid=$(pgrep svc-events 2> /dev/null)
-		if [[ $pid -eq 0 ]]; then
+		pid=$(pgrep -fc svc-events 2> /dev/null)
+		if [[ $? -ne 0 ]] || [[ $pid -gt 1 ]]; then
 			echo "svc-events has exited"
+			kill -15 ${OWN_PID}
 			exit 1
 		fi
 		sleep 5

--- a/install/Docker/dockerfiles/scripts/start_fabrics.sh
+++ b/install/Docker/dockerfiles/scripts/start_fabrics.sh
@@ -14,12 +14,12 @@
 # under the License.
 
 declare PID=0
+declare OWN_PID=$$
 
 sigterm_handler()
 {
         if [[ $PID -ne 0 ]]; then
-                # will wait for other instances to gracefully announce quorum exit
-                sleep 5
+                sleep 1
                 kill -9 $PID
                 wait "$PID" 2>/dev/null
         fi
@@ -40,24 +40,26 @@ run_forever()
 
 start_fabrics()
 {
-	cd /bin
-	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
         registry_address="consul:8500"
-        if [ $HA_ENABLED == true ]; then
+        if [[ ${HA_ENABLED,,} == true ]]; then
                 registry_address="[consul1:8500,consul2:8500,consul3:8500]"
         fi
-	nohup ./svc-fabrics --registry=consul --registry_address=${registry_address} --server_address=fabrics:45106 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/fabrics.log 2>&1 &
+
+	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
+	nohup /bin/svc-fabrics --registry=consul --registry_address=${registry_address} --server_address=fabrics:45106 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/fabrics.log 2>&1 &
 	PID=$!
-	sleep 2s
-	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/add-hosts.log 2>&1 &
+	sleep 3
+
+	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/fabrics-add-hosts.log 2>&1 &
 }
 
 monitor_process()
 {
         while true; do
-                pid=$(pgrep svc-fabrics 2> /dev/null)
-                if [[ $pid -eq 0 ]]; then
+                pid=$(pgrep -fc svc-fabrics 2> /dev/null)
+                if [[ $? -ne 0 ]] || [[ $pid -gt 1 ]]; then
                         echo "svc-fabrics has exited"
+			kill -15 ${OWN_PID}
                         exit 1
                 fi
                 sleep 5

--- a/install/Docker/dockerfiles/scripts/start_grfplugin.sh
+++ b/install/Docker/dockerfiles/scripts/start_grfplugin.sh
@@ -14,12 +14,12 @@
 # under the License.
 
 declare PID=0
+declare OWN_PID=$$
 
 sigterm_handler()
 {
         if [[ $PID -ne 0 ]]; then
-                # will wait for other instances to gracefully announce quorum exit
-                sleep 5
+                sleep 1
                 kill -9 $PID
                 wait "$PID" 2>/dev/null
         fi
@@ -40,20 +40,21 @@ run_forever()
 
 start_grfplugin()
 {
-	cd /bin
 	export PLUGIN_CONFIG_FILE_PATH=/etc/grfplugin_config/config.json
-	nohup ./plugin-redfish >> /var/log/grfplugin_logs/grfplugin.log 2>&1 &
+	nohup /bin/plugin-redfish >> /var/log/grfplugin_logs/grfplugin.log 2>&1 &
 	PID=$!
-	sleep 2s
-  nohup /bin/add-hosts -file /tmp/host.append >> /var/log/grfplugin_logs/add-hosts.log 2>&1 &
+	sleep 3
+
+	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/grfplugin_logs/add-hosts.log 2>&1 &
 }
 
 monitor_process()
 {
         while true; do
-                pid=$(pgrep plugin-redfish 2> /dev/null)
-                if [[ $pid -eq 0 ]]; then
+                pid=$(pgrep -fc plugin-redfish 2> /dev/null)
+                if [[ $? -ne 0 ]] || [[ $pid -gt 1 ]]; then
                         echo "plugin-redfish has exited" >> /var/log/grfplugin_logs/grfplugin.log 2>&1 &
+			kill -15 ${OWN_PID}
                         exit 1
                 fi
                 sleep 5

--- a/install/Docker/dockerfiles/scripts/start_managers.sh
+++ b/install/Docker/dockerfiles/scripts/start_managers.sh
@@ -14,12 +14,12 @@
 # under the License.
 
 declare PID=0
+declare OWN_PID=$$
 
 sigterm_handler()
 {
         if [[ $PID -ne 0 ]]; then
-                # will wait for other instances to gracefully announce quorum exit
-                sleep 5
+                sleep 1
                 kill -9 $PID
                 wait "$PID" 2>/dev/null
         fi
@@ -40,24 +40,26 @@ run_forever()
 
 start_manager()
 {
-	cd /bin
-	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
         registry_address="consul:8500"
-        if [ $HA_ENABLED == true ]; then
+        if [[ ${HA_ENABLED,,} == true ]]; then
                 registry_address="[consul1:8500,consul2:8500,consul3:8500]"
         fi
-	nohup ./svc-managers --registry=consul --registry_address=${registry_address} --server_address=managers:45107 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/managers.log 2>&1 &
+
+	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
+	nohup /bin/svc-managers --registry=consul --registry_address=${registry_address} --server_address=managers:45107 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/managers.log 2>&1 &
 	PID=$!
-	sleep 2s
-  nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/add-hosts.log 2>&1 &
+	sleep 3
+
+	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/managers-add-hosts.log 2>&1 &
 }
 
 monitor_process()
 {
         while true; do
-                pid=$(pgrep svc-managers 2> /dev/null)
-                if [[ $pid -eq 0 ]]; then
+                pid=$(pgrep -fc svc-managers 2> /dev/null)
+                if [[ $? -ne 0 ]] || [[ $pid -gt 1 ]]; then
                         echo "svc-managers has exited"
+			kill -15 ${OWN_PID}
                         exit 1
                 fi
                 sleep 5

--- a/install/Docker/dockerfiles/scripts/start_systems.sh
+++ b/install/Docker/dockerfiles/scripts/start_systems.sh
@@ -14,12 +14,12 @@
 # under the License.
 
 declare PID=0
+declare OWN_PID=$$
 
 sigterm_handler()
 {
         if [[ $PID -ne 0 ]]; then
-                # will wait for other instances to gracefully announce quorum exit
-                sleep 5
+                sleep 1
                 kill -9 $PID
                 wait "$PID" 2>/dev/null
         fi
@@ -40,24 +40,26 @@ run_forever()
 
 start_systems()
 {
-	cd /bin
-	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
         registry_address="consul:8500"
-        if [ $HA_ENABLED == true ]; then
+        if [[ ${HA_ENABLED,,} == true ]]; then
                 registry_address="[consul1:8500,consul2:8500,consul3:8500]"
         fi
-	nohup ./svc-systems --registry=consul --registry_address=${registry_address} --server_address=systems:45104 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/systems.log 2>&1 &
+
+	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
+	nohup /bin/svc-systems --registry=consul --registry_address=${registry_address} --server_address=systems:45104 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/systems.log 2>&1 &
 	PID=$!
-	sleep 2s
-	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/add-hosts.log 2>&1 &
+	sleep 3
+
+	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/systems-add-hosts.log 2>&1 &
 }
 
 monitor_process()
 {
         while true; do
-                pid=$(pgrep svc-systems 2> /dev/null)
-                if [[ $pid -eq 0 ]]; then
+                pid=$(pgrep -fc svc-systems 2> /dev/null)
+                if [[ $? -ne 0 ]] || [[ $pid -gt 1 ]]; then
                         echo "svc-systems has exited"
+			kill -15 ${OWN_PID}
                         exit 1
                 fi
                 sleep 5

--- a/install/Docker/dockerfiles/scripts/start_task.sh
+++ b/install/Docker/dockerfiles/scripts/start_task.sh
@@ -14,12 +14,12 @@
 # under the License.
 
 declare PID=0
+declare OWN_PID=$$
 
 sigterm_handler()
 {
         if [[ $PID -ne 0 ]]; then
-                # will wait for other instances to gracefully announce quorum exit
-                sleep 5
+                sleep 1
                 kill -9 $PID
                 wait "$PID" 2>/dev/null
         fi
@@ -40,24 +40,26 @@ run_forever()
 
 start_task()
 {
-	cd /bin
-	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
         registry_address="consul:8500"
-        if [ $HA_ENABLED == true ]; then
+        if [[ ${HA_ENABLED,,} == true ]]; then
                 registry_address="[consul1:8500,consul2:8500,consul3:8500]"
         fi
-	nohup ./svc-task --registry=consul --registry_address=${registry_address} --server_address=task:45105 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/task.log 2>&1 &
+
+	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
+	nohup /bin/svc-task --registry=consul --registry_address=${registry_address} --server_address=task:45105 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/task.log 2>&1 &
 	PID=$!
-	sleep 2s
-  	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/add-hosts.log 2>&1 &
+	sleep 3
+
+	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/task-add-hosts.log 2>&1 &
 }
 
 monitor_process()
 {
         while true; do
-                pid=$(pgrep svc-task 2> /dev/null)
-                if [[ $pid -eq 0 ]]; then
+                pid=$(pgrep -fc svc-task 2> /dev/null)
+                if [[ $? -ne 0 ]] || [[ $pid -gt 1 ]]; then
                         echo "svc-task has exited"
+			kill -15 ${OWN_PID}
                         exit 1
                 fi
                 sleep 5

--- a/install/Docker/dockerfiles/scripts/start_update.sh
+++ b/install/Docker/dockerfiles/scripts/start_update.sh
@@ -14,12 +14,12 @@
 # under the License.
 
 declare PID=0
+declare OWN_PID=$$
 
 sigterm_handler()
 {
         if [[ $PID -ne 0 ]]; then
-                # will wait for other instances to gracefully announce quorum exit
-                sleep 5
+                sleep 1
                 kill -9 $PID
                 wait "$PID" 2>/dev/null
         fi
@@ -40,24 +40,26 @@ run_forever()
 
 start_update()
 {
-	cd /bin
-	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
         registry_address="consul:8500"
-        if [ $HA_ENABLED == true ]; then
+        if [[ ${HA_ENABLED,,}} == true ]]; then
                 registry_address="[consul1:8500,consul2:8500,consul3:8500]"
         fi
-	nohup ./svc-update --registry=consul --registry_address=${registry_address} --server_address=update:45108 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/update.log 2>&1 &
+
+	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
+	nohup /bin/svc-update --registry=consul --registry_address=${registry_address} --server_address=update:45108 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/update.log 2>&1 &
 	PID=$!
-	sleep 2s
-  	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/add-hosts.log 2>&1 &
+	sleep 3
+
+	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/update-add-hosts.log 2>&1 &
 }
 
 monitor_process()
 {
         while true; do
-                pid=$(pgrep svc-update 2> /dev/null)
-                if [[ $pid -eq 0 ]]; then
+                pid=$(pgrep -fc svc-update 2> /dev/null)
+                if [[ $? -ne 0 ]] || [[ $pid -gt 1 ]]; then
                         echo "svc-update has exited"
+			kill -15 ${OWN_PID}
                         exit 1
                 fi
                 sleep 5


### PR DESCRIPTION
Below changes are made in this PR
- Check for count of required process inside container should be equal to 1
- Check for the pgrep command execution result code.
- Send sigterm to main process from the monitoring child process created for graceful exit.
- Perform case insensitive match for HA_ENABLED config.

Resolves: #375 