### PR TITLE
Odim: 461: Fix for Get on /redfish/v1/AggregationService/ResetActionInfo & /redfish/v1/AggregationService/SetDefaultBootOrderActionInfo are giving 404 error 

### DIFF
--- a/svc-aggregation/rpc/aggregator.go
+++ b/svc-aggregation/rpc/aggregator.go
@@ -80,12 +80,10 @@ func (a *Aggregator) GetAggregationService(ctx context.Context, req *aggregatorp
 		OdataID:      "/redfish/v1/AggregationService",
 		Actions: agresponse.Actions{
 			Reset: agresponse.Action{
-				Target:     "/redfish/v1/AggregationService/Actions/AggregationService.Reset/",
-				ActionInfo: "/redfish/v1/AggregationService/ResetActionInfo",
+				Target: "/redfish/v1/AggregationService/Actions/AggregationService.Reset/",
 			},
 			SetDefaultBootOrder: agresponse.Action{
-				Target:     "/redfish/v1/AggregationService/Actions/AggregationService.SetDefaultBootOrder/",
-				ActionInfo: "/redfish/v1/AggregationService/SetDefaultBootOrderActionInfo",
+				Target: "/redfish/v1/AggregationService/Actions/AggregationService.SetDefaultBootOrder/",
 			},
 		},
 		Aggregates: agresponse.OdataID{


### PR DESCRIPTION
This PR contains:
Removal of ActionInfo: "/redfish/v1/AggregationService/ResetActionInfo", 
and  "/redfish/v1/AggregationService/SetDefaultBootOrderActionInfo",
Since these URIs are not included in latest AggregationService schema.

Resolves: https://github.com/ODIM-Project/ODIM/issues/461