### PR TITLE
Issue-463 remove trailing slash in system collection uri @odata.id

### DIFF
--- a/svc-systems/systems/getresource.go
+++ b/svc-systems/systems/getresource.go
@@ -519,7 +519,7 @@ func SearchAndFilter(paramStr []string, resp response.RPC) (response.RPC, error)
 	}
 	systemCollection := sresponse.Collection{
 		OdataContext: "/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection",
-		OdataID:      "/redfish/v1/Systems/",
+		OdataID:      "/redfish/v1/Systems",
 		OdataType:    "#ComputerSystemCollection.ComputerSystemCollection",
 		Description:  "Computer Systems view",
 		Name:         "Computer Systems",
@@ -674,7 +674,7 @@ func GetSystemsCollection(req *systemsproto.GetSystemsRequest) response.RPC {
 	}
 	systemCollection := sresponse.Collection{
 		OdataContext: "/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection",
-		OdataID:      "/redfish/v1/Systems/",
+		OdataID:      "/redfish/v1/Systems",
 		OdataType:    "#ComputerSystemCollection.ComputerSystemCollection",
 		Description:  "Computer Systems view",
 		Name:         "Computer Systems",

--- a/svc-systems/systems/getresource_test.go
+++ b/svc-systems/systems/getresource_test.go
@@ -171,7 +171,7 @@ func TestGetAllSystems(t *testing.T) {
 	}
 	systemsCollection := sresponse.Collection{
 		OdataContext: "/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection",
-		OdataID:      "/redfish/v1/Systems/",
+		OdataID:      "/redfish/v1/Systems",
 		OdataType:    "#ComputerSystemCollection.ComputerSystemCollection",
 		Description:  "Computer Systems view",
 		Name:         "Computer Systems",
@@ -807,7 +807,7 @@ func TestGetAllSystemsWithMultipleIndexData(t *testing.T) {
 	}
 	systemsCollection := sresponse.Collection{
 		OdataContext: "/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection",
-		OdataID:      "/redfish/v1/Systems/",
+		OdataID:      "/redfish/v1/Systems",
 		OdataType:    "#ComputerSystemCollection.ComputerSystemCollection",
 		Description:  "Computer Systems view",
 		Name:         "Computer Systems",


### PR DESCRIPTION
Trailing "/" has to be removed from odata.id ("/redfish/v1/Systems/") as per Redfish.Uri standard mentioned in ComputerSystemCollection schema.