### PR TITLE
Odim 461: removed ActionInfo from Action struct

### DIFF
--- a/svc-aggregation/agresponse/rpc.go
+++ b/svc-aggregation/agresponse/rpc.go
@@ -59,7 +59,6 @@ type Status struct {
 //Action struct definition
 type Action struct {
 	Target     string `json:"target"`
-	ActionInfo string `json:"@Redfish.ActionInfo"`
 }
 
 //OdataID struct definition for @odata.id


### PR DESCRIPTION
Removed ActionInfo from Action struct in svc-aggregation.
As per the latest Aggregation schema, this is not included.
Resolves https://github.com/ODIM-Project/ODIM/issues/461