### PR TITLE
[Issue-499] Fix for Adding a new connection method in kube_deploy_nodes.yaml after editing and deleting it doesn't get reflected in ODIM

### DIFF
--- a/svc-aggregation/agcommon/common.go
+++ b/svc-aggregation/agcommon/common.go
@@ -169,8 +169,8 @@ func (e *DBInterface) AddConnectionMethods(connectionMethodConf []config.Connect
 func TrackConfigFileChanges(dbInterface DBInterface) {
 	eventChan := make(chan interface{})
 	go common.TrackConfigFileChanges(ConfigFilePath, eventChan)
-	select {
-	case <-eventChan: // new data arrives through eventChan channel
+	for {
+		log.Info(<-eventChan) // new data arrives through eventChan channel
 		config.TLSConfMutex.RLock()
 		err := dbInterface.AddConnectionMethods(config.Data.ConnectionMethodConf)
 		if err != nil {


### PR DESCRIPTION
The PR contains the fix for connection method update according to the config file changes.

Scenario: We were using a channel called `eventChan` for alerting the AddConnectionMethods function regarding the change in the config file. The message will be put into the channel from the lib-utilities function `TrackConfigFileChanges`.

Issue Found: The current implementation was having an issue that the messages from eventChan were only considered once. So the AddConnectionMethods function will be aware of only the first change that happened in the config file, the rest of the messages in the channel are not received by AddConnectionMethods.

Proposed Solution: We can add an infinite `for loop` which has the channel receiver in it so that AddConnectionMethods will be informed about all the changes in the config files. As channels have a blocking ability, each iteration of the for loop will be controlled by the messages in the channel.

closes #499 