### PR TITLE
Resolved the managers/chassis issue - a get on BMC manager was giving 404 error and delete server was not deleting the manager and chassis info

### DIFF
--- a/lib-utilities/common/mockconfig.go
+++ b/lib-utilities/common/mockconfig.go
@@ -64,16 +64,22 @@ func SetUpMockConfig() error {
 		},
 	}
 	config.Data.AddComputeSkipResources = &config.AddComputeSkipResources{
-		SystemCollection: []string{
+		SkipResourceListUnderSystem: []string{
+			"Chassis",
+			"Managers",
+			"LogServices",
+		},
+		SkipResourceListUnderManager: []string{
+			"Systems",
 			"Chassis",
 			"LogServices",
 		},
-		ChassisCollection: []string{
+		SkipResourceListUnderChassis: []string{
 			"Managers",
 			"Systems",
 			"Devices",
 		},
-		OtherCollection: []string{
+		SkipResourceListUnderOthers: []string{
 			"Power",
 			"Thermal",
 			"SmartStorage",
@@ -100,7 +106,7 @@ func SetUpMockConfig() error {
 		StartUpResouceBatchSize: 10,
 	}
 	config.Data.AddComputeSkipResources = &config.AddComputeSkipResources{
-		OtherCollection: []string{"Power", "Thermal", "SmartStorage", "LogServices"},
+		SkipResourceListUnderOthers: []string{"Power", "Thermal", "SmartStorage", "LogServices"},
 	}
 	return nil
 }

--- a/lib-utilities/config/README.md
+++ b/lib-utilities/config/README.md
@@ -32,9 +32,9 @@
 |PasswordRules||MaxPasswordLength|integer|This holds the value of max password length
 |PasswordRules||AllowedSpecialCharcters|string|This holds all value of all sppecial charcters
 |AddComputeSkipResources|collection|||This stores all resource which need to igonered while adding Computer System
-|AddComputeSkipResources||SystemCollection|list of strings|This holds the value of system resource which need to be ignored
-|AddComputeSkipResources||ChassisCollection|list of strings|This holds the value of chassis resource which need to be ignored
-|AddComputeSkipResources||OtherCollection|list of strings|This holds the value resource name for which next level retrieval to be ignored
+|AddComputeSkipResources||SkipResourceListUnderSystem|list of strings|This holds the value of system resource which need to be ignored
+|AddComputeSkipResources||SkipResourceListUnderChassis|list of strings|This holds the value of chassis resource which need to be ignored
+|AddComputeSkipResources||SkipResourceListUnderOthers|list of strings|This holds the value resource name for which next level retrieval to be ignored
 |URLTranslation|collection|||This holds the north bound and south bound urls
 |URLTranslation||NorthBoundURL.ODIM|collection of strings| This the north bound urls
 |URLTranslation||SouthBoundURL.redfish|collection of strings| This holds the south bound urls

--- a/lib-utilities/config/config.go
+++ b/lib-utilities/config/config.go
@@ -107,11 +107,12 @@ type APIGatewayConf struct {
 	Certificate     []byte
 }
 
-// AddComputeSkipResources stores all resource which need to igonered while adding Computer System
+// AddComputeSkipResources stores list of resources which need to ignored while inserting the contents to DB while adding Computer System
 type AddComputeSkipResources struct {
-	SystemCollection  []string `json:"SystemCollection"`  // holds the value of  system resource which need to be ignored
-	ChassisCollection []string `json:"ChassisCollection"` // holds the value of  chassis resource which need to be ignored
-	OtherCollection   []string `json:"OtherCollection"`   // holds the value resource name  for which next level retrieval to be ignored
+	SkipResourceListUnderSystem  []string `json:"SkipResourceListUnderSystem"`  // holds the list of resources which needs to be ignored for storing in DB under system resource
+	SkipResourceListUnderManager []string `json:"SkipResourceListUnderManager"` // holds the list of resources which needs to be ignored for storing in DB under manager resource
+	SkipResourceListUnderChassis []string `json:"SkipResourceListUnderChassis"` // holds the list of resources which needs to be ignored for storing in DB under chassis resource
+	SkipResourceListUnderOthers  []string `json:"SkipResourceListUnderOthers"`  // holds the list of resources which needs to be ignored for storing in DB under a generic resource apart from system,manager and chassis
 }
 
 // URLTranslation ...
@@ -381,23 +382,28 @@ func checkAddComputeSkipResources() {
 	if Data.AddComputeSkipResources == nil {
 		log.Warn("No value found for AddComputeRetrival, setting default value")
 		Data.AddComputeSkipResources = &AddComputeSkipResources{
-			SystemCollection:  DefaultSystemCollection,
-			ChassisCollection: DefaultChassisCollection,
-			OtherCollection:   DefaultOtherCollection,
+			SkipResourceListUnderSystem:  DefaultSkipListUnderSystem,
+			SkipResourceListUnderManager: DefaultSkipListUnderManager,
+			SkipResourceListUnderChassis: DefaultSkipListUnderChassis,
+			SkipResourceListUnderOthers:  DefaultSkipListUnderOthers,
 		}
 		return
 	}
-	if len(Data.AddComputeSkipResources.SystemCollection) == 0 {
-		log.Warn("No value found for SystemCollection, setting default value")
-		Data.AddComputeSkipResources.SystemCollection = DefaultSystemCollection
+	if len(Data.AddComputeSkipResources.SkipResourceListUnderSystem) == 0 {
+		log.Warn("No value found for SkipResourceListUnderSystem, setting default value")
+		Data.AddComputeSkipResources.SkipResourceListUnderSystem = DefaultSkipListUnderSystem
 	}
-	if len(Data.AddComputeSkipResources.ChassisCollection) == 0 {
-		log.Warn("No value found for ChassisCollection, setting default value")
-		Data.AddComputeSkipResources.ChassisCollection = DefaultChassisCollection
+	if len(Data.AddComputeSkipResources.SkipResourceListUnderManager) == 0 {
+		log.Warn("No value found for SkipResourceListUnderManager, setting default value")
+		Data.AddComputeSkipResources.SkipResourceListUnderManager = DefaultSkipListUnderManager
 	}
-	if len(Data.AddComputeSkipResources.OtherCollection) == 0 {
-		log.Warn("No value found for OtherCollection, setting default value")
-		Data.AddComputeSkipResources.OtherCollection = DefaultOtherCollection
+	if len(Data.AddComputeSkipResources.SkipResourceListUnderChassis) == 0 {
+		log.Warn("No value found for SkipResourceListUnderChassis, setting default value")
+		Data.AddComputeSkipResources.SkipResourceListUnderChassis = DefaultSkipListUnderChassis
+	}
+	if len(Data.AddComputeSkipResources.SkipResourceListUnderOthers) == 0 {
+		log.Warn("No value found for SkipResourceListUnderOthers, setting default value")
+		Data.AddComputeSkipResources.SkipResourceListUnderOthers = DefaultSkipListUnderOthers
 	}
 }
 

--- a/lib-utilities/config/config_test.go
+++ b/lib-utilities/config/config_test.go
@@ -84,16 +84,22 @@ func TestSetConfiguration(t *testing.T) {
                 }
         },
         "AddComputeSkipResources": {
-                "SystemCollection": [
+                "SkipResourceListUnderSystem": [
                         "Chassis",
+                        "LogServices",
+						"Managers"
+                ],
+				"SkipResourceListUnderManager": [
+                        "Chassis",
+                        "Systems",
                         "LogServices"
                 ],
-                "ChassisCollection": [
+                "SkipResourceListUnderChassis": [
                         "Managers",
                         "Systems",
                         "Devices"
                 ],
-                "OtherCollection": [
+                "SkipResourceListUnderOthers": [
                         "Power",
                         "Thermal",
                         "SmartStorage",
@@ -404,15 +410,19 @@ func TestValidateConfigurationGroup3(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "Invalid value for AddComputeSkipResources.ChassisCollection",
+			name:    "Invalid value for AddComputeSkipResources.SkipResourceListUnderChassis",
 			wantErr: false,
 		},
 		{
-			name:    "Invalid value for AddComputeSkipResources.OtherCollection",
+			name:    "Invalid value for AddComputeSkipResources.SkipResourceListUnderOthers",
 			wantErr: false,
 		},
 		{
 			name:    "Invalid value for URLTranslation",
+			wantErr: false,
+		},
+		{
+			name:    "Invalid value for AddComputeSkipResources.SkipResourceListUnderManager",
 			wantErr: false,
 		},
 	}
@@ -449,18 +459,20 @@ func TestValidateConfigurationGroup3(t *testing.T) {
 			Data.APIGatewayConf.CertificatePath = sampleFileForTest
 		case 8:
 			Data.AddComputeSkipResources = &AddComputeSkipResources{
-				SystemCollection: []string{"Chassis", "LogServices"},
+				SkipResourceListUnderSystem: []string{"Chassis", "LogServices", "Manager"},
 			}
 		case 9:
-			Data.AddComputeSkipResources.ChassisCollection = []string{"Managers", "Systems", "Devices"}
+			Data.AddComputeSkipResources.SkipResourceListUnderChassis = []string{"Managers", "Systems", "Devices"}
 		case 10:
-			Data.AddComputeSkipResources.OtherCollection = []string{"Power", "Thermal", "SmartStorage"}
+			Data.AddComputeSkipResources.SkipResourceListUnderOthers = []string{"Power", "Thermal", "SmartStorage"}
 		case 11:
 			Data.URLTranslation = &URLTranslation{
 				NorthBoundURL: map[string]string{},
 				SouthBoundURL: map[string]string{},
 			}
 			Data.PluginStatusPolling = &PluginStatusPolling{}
+		case 12:
+			Data.AddComputeSkipResources.SkipResourceListUnderManager = []string{"Chassis", "Systems", "LogServices"}
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			if err := ValidateConfiguration(); (err != nil) != tt.wantErr {

--- a/lib-utilities/config/constants.go
+++ b/lib-utilities/config/constants.go
@@ -93,12 +93,14 @@ const (
 )
 
 var (
-	// DefaultSystemCollection - default SystemCollection value
-	DefaultSystemCollection = []string{"Chassis", "LogServices"}
-	// DefaultChassisCollection - default ChassisCollection value
-	DefaultChassisCollection = []string{"Managers", "Systems", "Devices"}
-	// DefaultOtherCollection - default OtherCollection value
-	DefaultOtherCollection = []string{"Power", "Thermal", "SmartStorage"}
+	// DefaultSkipListUnderSystem - holds the default list of resources which needs to be ignored for storing in DB under system resource
+	DefaultSkipListUnderSystem = []string{"Chassis", "LogServices", "Managers"}
+	// DefaultSkipListUnderManager - holds the default list of resources which needs to be ignored for storing in DB under manager resource
+	DefaultSkipListUnderManager = []string{"Chassis", "LogServices", "Systems"}
+	// DefaultSkipListUnderChassis - holds the default list of resources which needs to be ignored for storing in DB under chassis resource
+	DefaultSkipListUnderChassis = []string{"Managers", "Systems", "Devices"}
+	// DefaultSkipListUnderOthers - holds the default list of resources which needs to be ignored for storing in DB under any other resource
+	DefaultSkipListUnderOthers = []string{"Power", "Thermal", "SmartStorage"}
 	// DefaultCipherSuiteList - default cipher suite list
 	DefaultCipherSuiteList = []uint16{
 		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,

--- a/lib-utilities/config/mockconfig.go
+++ b/lib-utilities/config/mockconfig.go
@@ -203,16 +203,22 @@ func SetUpMockConfig(t *testing.T) error {
 		Certificate: hostCert,
 	}
 	Data.AddComputeSkipResources = &AddComputeSkipResources{
-		SystemCollection: []string{
+		SkipResourceListUnderSystem: []string{
+			"Chassis",
+			"LogServices",
+			"Managers",
+		},
+		SkipResourceListUnderManager: []string{
+			"Systems",
 			"Chassis",
 			"LogServices",
 		},
-		ChassisCollection: []string{
+		SkipResourceListUnderChassis: []string{
 			"Managers",
 			"Systems",
 			"Devices",
 		},
-		OtherCollection: []string{
+		SkipResourceListUnderOthers: []string{
 			"Power",
 			"Thermal",
 			"SmartStorage",

--- a/lib-utilities/config/odimra_config.json
+++ b/lib-utilities/config/odimra_config.json
@@ -57,17 +57,24 @@
 		}
 	},
 	"AddComputeSkipResources": { 
-		"SystemCollection": [ 
+		"SkipResourceListUnderSystem": [ 
+			"Chassis",
+			"Managers",
+			"LogServices",
+			"WorkloadPerformanceAdvisor"
+		],
+		"SkipResourceListUnderManager": [
+			"Systems",
 			"Chassis",
 			"LogServices",
 			"WorkloadPerformanceAdvisor"
 		],
-		"ChassisCollection": [ 
+		"SkipResourceListUnderChassis": [ 
 			"Managers",
 			"Systems",
 			"Devices"
 		],
-		"OtherCollection": [
+		"SkipResourceListUnderOthers": [
 			"Power",
 			"Thermal",
 			"SmartStorage",

--- a/odim-controller/helmcharts/odimra-config/templates/configmaps.yaml
+++ b/odim-controller/helmcharts/odimra-config/templates/configmaps.yaml
@@ -72,17 +72,24 @@ data:
     		}
     	},
     	"AddComputeSkipResources": {
-    		"SystemCollection": [
+    		"SkipResourceListUnderSystem": [
     			"Chassis",
     			"LogServices",
-    			"WorkloadPerformanceAdvisor"
+                        "Managers",
+    			"WorkloadPerformanceAdvisor"                
     		],
-    		"ChassisCollection": [
+                "SkipResourceListUnderManager": [
+    			"Systems",
+                        "Chassis",
+    			"LogServices",
+                        "WorkloadPerformanceAdvisor"
+    		],
+    		"SkipResourceListUnderChassis": [
     			"Managers",
     			"Systems",
     			"Devices"
     		],
-    		"OtherCollection": [
+    		"SkipResourceListUnderOthers": [
     			"Power",
     			"Thermal",
     			"SmartStorage",

--- a/svc-aggregation/agmessagebus/publish.go
+++ b/svc-aggregation/agmessagebus/publish.go
@@ -65,12 +65,12 @@ func Publish(systemID, eventType, collectionType string) {
 
 // PublishCtrlMsg publishes ODIM control messages to the message bus
 func PublishCtrlMsg(msgType common.ControlMessage, msg interface{}) error {
-	kConn, err := dc.Communicator(dc.KAFKA, config.Data.MessageQueueConfigFilePath)
+	conn, err := dc.Communicator(dc.KAFKA, config.Data.MessageQueueConfigFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to get kafka connection: %s", err.Error())
 	}
 
-	defer kConn.Close()
+	defer conn.Close()
 	data, err := json.Marshal(msg)
 	if err != nil {
 		return fmt.Errorf("failed to marshal data: %s", err.Error())
@@ -79,7 +79,7 @@ func PublishCtrlMsg(msgType common.ControlMessage, msg interface{}) error {
 		MessageType: msgType,
 		Data:        data,
 	}
-	if err := kConn.Distribute(common.InterCommMsgQueueName, ctrlMsg); err != nil {
+	if err := conn.Distribute(common.InterCommMsgQueueName, ctrlMsg); err != nil {
 		return fmt.Errorf("failed to write data to kafka: %s", err.Error())
 	}
 	return nil

--- a/svc-aggregation/agmodel/system.go
+++ b/svc-aggregation/agmodel/system.go
@@ -339,7 +339,7 @@ func DeleteComputeSystem(index int, key string) *errors.Error {
 	}
 
 	//Delete All resources
-	deleteKey := "*" + key[index+1:] + "*"
+	deleteKey := "*" + systemID + "*"
 	if err = connPool.DeleteServer(deleteKey); err != nil {
 		return errors.PackError(err.ErrNo(), "error while trying to delete compute system: ", err.Error())
 	}

--- a/svc-aggregation/rpc/aggregator_test.go
+++ b/svc-aggregation/rpc/aggregator_test.go
@@ -351,7 +351,7 @@ func TestAggregator_ValidateManagerAddress(t *testing.T) {
 func TestAggregator_AddAggreagationSource(t *testing.T) {
 	config.SetUpMockConfig(t)
 	addComputeRetrieval := config.AddComputeSkipResources{
-		SystemCollection: []string{"Chassis", "LogServices"},
+		SkipResourceListUnderSystem: []string{"Chassis", "LogServices"},
 	}
 	mockPluginData(t, "ILO_v1.0.0")
 

--- a/svc-aggregation/system/addaggregationsource_test.go
+++ b/svc-aggregation/system/addaggregationsource_test.go
@@ -38,7 +38,7 @@ func TestExternalInterface_AddBMC(t *testing.T) {
 	config.SetUpMockConfig(t)
 	common.MuxLock.Unlock()
 	addComputeRetrieval := config.AddComputeSkipResources{
-		SystemCollection: []string{"Chassis", "LogServices"},
+		SkipResourceListUnderSystem: []string{"Chassis", "LogServices"},
 	}
 	config.Data.AddComputeSkipResources = &addComputeRetrieval
 	defer func() {
@@ -249,7 +249,7 @@ func TestExternalInterface_AddBMCForPasswordEncryptFail(t *testing.T) {
 	config.SetUpMockConfig(t)
 	common.MuxLock.Unlock()
 	addComputeRetrieval := config.AddComputeSkipResources{
-		SystemCollection: []string{"Chassis", "LogServices"},
+		SkipResourceListUnderSystem: []string{"Chassis", "LogServices"},
 	}
 	config.Data.AddComputeSkipResources = &addComputeRetrieval
 	defer func() {
@@ -316,7 +316,7 @@ func TestExternalInterface_AddBMCDuplicate(t *testing.T) {
 	config.SetUpMockConfig(t)
 	common.MuxLock.Unlock()
 	addComputeRetrieval := config.AddComputeSkipResources{
-		SystemCollection: []string{"Chassis", "LogServices"},
+		SkipResourceListUnderSystem: []string{"Chassis", "LogServices"},
 	}
 	config.Data.AddComputeSkipResources = &addComputeRetrieval
 	defer func() {
@@ -378,7 +378,7 @@ func TestExternalInterface_Manager(t *testing.T) {
 	config.SetUpMockConfig(t)
 	common.MuxLock.Unlock()
 	addComputeRetrieval := config.AddComputeSkipResources{
-		SystemCollection: []string{"Chassis", "LogServices"},
+		SkipResourceListUnderSystem: []string{"Chassis", "LogServices"},
 	}
 	err := mockPluginData(t, "ILO_v1.0.0")
 	if err != nil {
@@ -573,7 +573,7 @@ func TestExternalInterface_ManagerXAuth(t *testing.T) {
 	config.SetUpMockConfig(t)
 	common.MuxLock.Unlock()
 	addComputeRetrieval := config.AddComputeSkipResources{
-		SystemCollection: []string{"Chassis", "LogServices"},
+		SkipResourceListUnderSystem: []string{"Chassis", "LogServices"},
 	}
 	err := mockPluginData(t, "XAuthPlugin_v1.0.0")
 	if err != nil {
@@ -770,7 +770,7 @@ func TestExternalInterface_ManagerWithMultipleRequest(t *testing.T) {
 	config.SetUpMockConfig(t)
 	common.MuxLock.Unlock()
 	addComputeRetrieval := config.AddComputeSkipResources{
-		SystemCollection: []string{"Chassis", "LogServices"},
+		SkipResourceListUnderSystem: []string{"Chassis", "LogServices"},
 	}
 	config.Data.AddComputeSkipResources = &addComputeRetrieval
 	defer func() {

--- a/svc-aggregation/system/addcompute_test.go
+++ b/svc-aggregation/system/addcompute_test.go
@@ -226,7 +226,7 @@ func TestExternalInterface_addcompute(t *testing.T) {
 	config.SetUpMockConfig(t)
 	common.MuxLock.Unlock()
 	addComputeRetrieval := config.AddComputeSkipResources{
-		SystemCollection: []string{"Chassis", "LogServices"},
+		SkipResourceListUnderSystem: []string{"Chassis", "LogServices"},
 	}
 	config.Data.AddComputeSkipResources = &addComputeRetrieval
 	defer func() {

--- a/svc-aggregation/system/addplugin_test.go
+++ b/svc-aggregation/system/addplugin_test.go
@@ -82,7 +82,7 @@ func mockDupMgrAddrPluginData(t *testing.T, pluginID string) error {
 func TestExternalInterface_Plugin(t *testing.T) {
 	config.SetUpMockConfig(t)
 	addComputeRetrieval := config.AddComputeSkipResources{
-		SystemCollection: []string{"Chassis", "LogServices"},
+		SkipResourceListUnderSystem: []string{"Chassis", "LogServices"},
 	}
 	err := mockPluginData(t, "ILO_v1.0.0")
 	if err != nil {
@@ -284,7 +284,7 @@ func TestExternalInterface_Plugin(t *testing.T) {
 func TestExternalInterface_PluginXAuth(t *testing.T) {
 	config.SetUpMockConfig(t)
 	addComputeRetrieval := config.AddComputeSkipResources{
-		SystemCollection: []string{"Chassis", "LogServices"},
+		SkipResourceListUnderSystem: []string{"Chassis", "LogServices"},
 	}
 	err := mockPluginData(t, "XAuthPlugin_v1.0.0")
 	if err != nil {

--- a/svc-aggregation/system/common.go
+++ b/svc-aggregation/system/common.go
@@ -532,7 +532,7 @@ func isFileExist(existingFiles []string, substr string) bool {
 	return fileExist
 }
 
-func (h *respHolder) getAllRootInfo(taskID string, progress int32, alottedWork int32, req getResourceRequest) int32 {
+func (h *respHolder) getAllRootInfo(taskID string, progress int32, alottedWork int32, req getResourceRequest, resourceList []string) int32 {
 	resourceName := req.OID
 	body, _, getResponse, err := contactPlugin(req, "error while trying to get the"+resourceName+"collection details: ")
 	if err != nil {
@@ -565,7 +565,7 @@ func (h *respHolder) getAllRootInfo(taskID string, progress int32, alottedWork i
 		estimatedWork := alottedWork / int32(len(resourceMembers.([]interface{})))
 		oDataID := object.(map[string]interface{})["@odata.id"].(string)
 		req.OID = oDataID
-		progress = h.getIndivdualInfo(taskID, progress, estimatedWork, req)
+		progress = h.getIndivdualInfo(taskID, progress, estimatedWork, req, resourceList)
 	}
 	return progress
 }
@@ -636,10 +636,9 @@ func (h *respHolder) getSystemInfo(taskID string, progress int32, alottedWork in
 	h.TraversedLinks[req.OID] = true
 	h.SystemURL = append(h.SystemURL, oidKey)
 	var retrievalLinks = make(map[string]bool)
+
 	getLinks(computeSystem, retrievalLinks, false)
-
-	removeRetrievalLinks(retrievalLinks, oid, config.Data.AddComputeSkipResources.SystemCollection, h.TraversedLinks)
-
+	removeRetrievalLinks(retrievalLinks, oid, config.Data.AddComputeSkipResources.SkipResourceListUnderSystem, h.TraversedLinks)
 	req.SystemID = computeSystemID
 	req.ParentOID = oid
 	for resourceOID, oemFlag := range retrievalLinks {
@@ -728,10 +727,9 @@ func (h *respHolder) getStorageInfo(progress int32, alottedWork int32, req getRe
 	h.TraversedLinks[req.OID] = true
 	h.SystemURL = append(h.SystemURL, oidKey)
 	var retrievalLinks = make(map[string]bool)
+
 	getLinks(computeSystem, retrievalLinks, false)
-
-	removeRetrievalLinks(retrievalLinks, oid, config.Data.AddComputeSkipResources.SystemCollection, h.TraversedLinks)
-
+	removeRetrievalLinks(retrievalLinks, oid, config.Data.AddComputeSkipResources.SkipResourceListUnderSystem, h.TraversedLinks)
 	req.SystemID = computeSystemID
 	req.ParentOID = oid
 	for resourceOID, oemFlag := range retrievalLinks {
@@ -781,7 +779,7 @@ func createServerSearchIndex(computeSystem map[string]interface{}, oidKey, devic
 
 	// saving the firmware version
 	if !strings.Contains(oidKey, "/Storage") {
-		if firmwareVersion := getFirmwareVersion(oidKey); firmwareVersion != "" {
+		if firmwareVersion := getFirmwareVersion(oidKey, deviceUUID); firmwareVersion != "" {
 			searchForm["FirmwareVersion"] = firmwareVersion
 		}
 	}
@@ -831,7 +829,7 @@ func createServerSearchIndex(computeSystem map[string]interface{}, oidKey, devic
 	}
 	return searchForm
 }
-func (h *respHolder) getIndivdualInfo(taskID string, progress int32, alottedWork int32, req getResourceRequest) int32 {
+func (h *respHolder) getIndivdualInfo(taskID string, progress int32, alottedWork int32, req getResourceRequest, resourceList []string) int32 {
 	resourceName := getResourceName(req.OID, false)
 	body, _, getResponse, err := contactPlugin(req, "error while trying to get "+resourceName+" details: ")
 	if err != nil {
@@ -871,10 +869,9 @@ func (h *respHolder) getIndivdualInfo(taskID string, progress int32, alottedWork
 	}
 	h.TraversedLinks[req.OID] = true
 	var retrievalLinks = make(map[string]bool)
+
 	getLinks(resource, retrievalLinks, false)
-
-	removeRetrievalLinks(retrievalLinks, oid, config.Data.AddComputeSkipResources.ChassisCollection, h.TraversedLinks)
-
+	removeRetrievalLinks(retrievalLinks, oid, resourceList, h.TraversedLinks)
 	req.SystemID = resourceID
 	req.ParentOID = oid
 	for resourceOID, oemFlag := range retrievalLinks {
@@ -909,7 +906,14 @@ func (h *respHolder) getResourceDetails(taskID string, progress int32, alottedWo
 		h.lock.Unlock()
 		return progress
 	}
-	oidKey := keyFormation(req.OID, req.SystemID, req.DeviceUUID)
+
+	oidKey := req.OID
+	if strings.Contains(oidKey, "/redfish/v1/Managers/") || strings.Contains(oidKey, "/redfish/v1/Chassis/") {
+		oidKey = strings.Replace(oidKey, "/redfish/v1/Managers/", "/redfish/v1/Managers/"+req.DeviceUUID+":", -1)
+		oidKey = strings.Replace(oidKey, "/redfish/v1/Chassis/", "/redfish/v1/Chassis/"+req.DeviceUUID+":", -1)
+	} else {
+		oidKey = keyFormation(req.OID, req.SystemID, req.DeviceUUID)
+	}
 	var memberFlag bool
 	if _, ok := resourceData["Members"]; ok {
 		memberFlag = true
@@ -933,6 +937,7 @@ func (h *respHolder) getResourceDetails(taskID string, progress int32, alottedWo
 		return progress
 	}
 	var retrievalLinks = make(map[string]bool)
+
 	getLinks(resourceData, retrievalLinks, req.OemFlag)
 	/* Loop through  Collection members and discover all of them*/
 	for oid, oemFlag := range retrievalLinks {
@@ -1013,7 +1018,7 @@ func checkRetrieval(oid, parentoid string, traversedLinks map[string]bool) bool 
 	}
 	//skiping the Retrieval if parent oid contains links in other resource of config
 	// TODO : beyond second level Retrieval need to be taken from config it will be implemented in RUCE-1239
-	for _, resourceName := range config.Data.AddComputeSkipResources.OtherCollection {
+	for _, resourceName := range config.Data.AddComputeSkipResources.SkipResourceListUnderOthers {
 		if strings.Contains(parentoid, resourceName) {
 			return false
 		}
@@ -1064,12 +1069,22 @@ func updateManagerName(data []byte, pluginID string) []byte {
 	return data
 }
 
-func getFirmwareVersion(oid string) string {
-	// replace the system with the manager
-	managerID := strings.Replace(oid, "Systems", "Managers", -1)
-	data, dbErr := agmodel.GetResource("Managers", managerID)
-	if dbErr != nil {
-		log.Error("error while getting the managers data" + dbErr.Error())
+func getFirmwareVersion(oid, deviceUUID string) string {
+	strArray := strings.Split(oid, "/")
+	id := strArray[len(strArray)-1]
+	key := strings.Replace(oid, "/"+id, "/"+deviceUUID+":", -1)
+	key = strings.Replace(key, "Systems", "Managers", -1)
+	keys, dberr := agmodel.GetAllMatchingDetails("Managers", key, common.InMemory)
+	if dberr != nil {
+		log.Error("while getting the managers data" + dberr.Error())
+		return ""
+	} else if len(keys) == 0 {
+		log.Error("Manager data is not available")
+		return ""
+	}
+	data, dberr := agmodel.GetResource("Managers", keys[0])
+	if dberr != nil {
+		log.Error("while getting the managers data: ", dberr.Error())
 		return ""
 	}
 	// unmarshall the managers data

--- a/svc-aggregation/system/deleteaggregationsource.go
+++ b/svc-aggregation/system/deleteaggregationsource.go
@@ -296,7 +296,8 @@ func (e *ExternalInterface) deleteCompute(key string, index int) response.RPC {
 		log.Error("error while deleting the event subscription for " + key + " :" + string(subResponse.Body))
 	}
 
-	chassisList, derr := agmodel.GetAllMatchingDetails("Chassis", key[index+1:], common.InMemory)
+	keys := strings.Split(key[index+1:], ":")
+	chassisList, derr := agmodel.GetAllMatchingDetails("Chassis", keys[0], common.InMemory)
 	if derr != nil {
 		log.Error("error while trying to collect the chassis list: " + derr.Error())
 	}

--- a/svc-systems/scommon/common.go
+++ b/svc-systems/scommon/common.go
@@ -244,7 +244,7 @@ func ContactPlugin(req PluginContactRequest, errorMessage string) ([]byte, strin
 
 func checkRetrievalInfo(oid string) bool {
 	//skiping the Retrieval if parent oid contains links in other resource of config
-	for _, resourceName := range config.Data.AddComputeSkipResources.OtherCollection {
+	for _, resourceName := range config.Data.AddComputeSkipResources.SkipResourceListUnderOthers {
 		if strings.Contains(oid, resourceName) {
 			return false
 		}

--- a/svc-update/ucommon/common.go
+++ b/svc-update/ucommon/common.go
@@ -242,7 +242,7 @@ func ContactPlugin(req PluginContactRequest, errorMessage string) ([]byte, strin
 
 func checkRetrievalInfo(oid string) bool {
 	//skiping the Retrieval if parent oid contains links in other resource of config
-	for _, resourceName := range config.Data.AddComputeSkipResources.OtherCollection {
+	for _, resourceName := range config.Data.AddComputeSkipResources.SkipResourceListUnderOthers {
 		if strings.Contains(oid, resourceName) {
 			return false
 		}


### PR DESCRIPTION
Resolved the issue - A Get on a added dell server manager URL containing the ODIM generated UUID was returning 404 Not Found error instead of 200 OK
Even in the manager collection, the manager id for Dell server manager was not having UUID. Resolved this
The issue was if a system id and manager id is different then manager was giving 404, now handled this for any manager id
Resolved the issue - Chassis was showing duplicate resources when using dell plugin
Resolved the issue - Chassis and Manager resource where not getting deleted when a delete server is performed