### PR TITLE
Remove Lenovo instances from the main getting started readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
    - [Deploying the resource aggregator services](#deploying-the-resource-aggregator-services)
    - [Deploying the Unmanaged Rack Plugin \(URP\)](#deploying-the-unmanaged-rack-plugin)
    - [Deploying the Dell plugin](#deploying-the-dell-plugin)
-   - [Deploying the Lenovo plugin](#deploying-the-lenovo-plugin)
    - [Deploying the Cisco ACI plugin](#deploying-the-cisco-aci-plugin)
    - [Adding a plugin into the Resource Aggregator for ODIM framework](#adding-a-plugin-into-the-resource-aggregator-for-odim-framework)
 5. [Use cases for Resource Aggregator for ODIM](#use-cases-for-resource-aggregator-for-odim)
@@ -240,7 +239,7 @@ The following table lists the software components and their versions that are co
 - Cluster nodes:
     - To add 1,000 servers or less, you require nodes having 12 GB (12288 MB) RAM, 8 CPU cores and 16 threads, and 200 GB HDD each
 
-    - To add 5,000 servers or less, you require nodes having 32 GB (32768) RAM, 16 CPU cores and 32 threads, and 200GB HDD each
+    - To add 5,000 servers or less, you require nodes having 32 GB (32768 MB) RAM, 16 CPU cores and 32 threads, and 200GB HDD each
 
 
 1. Download and install Ubuntu 18.04 LTS on the deployment node and all the cluster nodes. 
@@ -567,8 +566,7 @@ Resource Aggregator for ODIM uses the odim-vault tool to encrypt and decrypt pas
 1. [Deploying the resource aggregator services](#deploying-the-resource-aggregator-services)
 2. [Deploying the Unmanaged Rack Plugin \(URP\)](#deploying-the-unmanaged-rack-plugin)
 3. [Deploying the Dell plugin](#deploying-the-dell-plugin)
-4. [Deploying the Lenovo plugin](#deploying-the-lenovo-plugin)
-5. [Deploying the Cisco ACI plugin](#deploying-the-cisco-aci-plugin)
+4. [Deploying the Cisco ACI plugin](#deploying-the-cisco-aci-plugin)
 6. [Adding a plugin into the Resource Aggregator for ODIM framework](#adding-a-plugin-into-the-resource-aggregator-for-odim-framework)
 
 ## Deploying the resource aggregator services
@@ -1353,125 +1351,6 @@ Kubernetes cluster is set up and the resource aggregator is successfully deploye
 
 16. [Add the Dell plugin into the Resource Aggregator for ODIM framework](#adding-a-plugin-into-the-resource-aggregator-for-odim-framework). 
 
-## Deploying the Lenovo plugin
-
-**Prerequisites**
-
-Kubernetes cluster is set up and the resource aggregator is successfully deployed.
-
-1. Create a directory called `plugins` on the deployment node.
-
-        $ mkdir plugins
-    
-2. In the `plugins` directory, create a directory called `lenovoplugin`.
-
-        $ mkdir ~/plugins/lenovoplugin
-    
-3. Log in to each cluster node and run the following commands: 
-
-        $ sudo mkdir -p /var/log/lenovoplugin_logs/
-        
-        $ sudo chown odimra:odimra /var/log/lenovoplugin_logs
-
-4. On the deployment node, copy the Lenovo plugin configuration file to `~/plugins/lenovoplugin`:
-
-        $ cp ~/ODIM/odim-controller/helmcharts/lenovoplugin/lenovoplugin-config.yaml ~/plugins/lenovoplugin
-    
-5. Open the Lenovo plugin configuration YAML file. 
-
-        $ vi ~/plugins/lenovoplugin/lenovoplugin-config.yaml
-    **Sample lenovoplugin-config.yaml file:**
-   ```
-    odimra:
-    namespace: odim
-    groupID: 2021
-    lenovoplugin:
-     hostname: knode1
-     eventListenerNodePort: 30089
-     lenovoPluginRootServiceUUID: 7a38b735-8b9f-48a0-b3e7-e5a180567d37
-     username: admin
-     password: sTfTyTZFvNj5zU5Tt0TfyDYU-ye3_ZqTMnMIj-LAeXaa8vCnBqq8Ga7zV6ZdfqQCdSAzmaO5AJxccD99UHLVlQ==
-     lbHost: 10.24.1.232
-     lbPort: 30089
-     logPath: /var/log/lenovoplugin_logs
-   ```
-   
-6. Update the following parameters in the plugin configuration file: 
-
-    - **hostname**: Hostname of the cluster node where the Lenovo plugin will be installed.
-    - **lbHost**: IP address of the cluster node where the Lenovo plugin will be installed for one node cluster configuration. For three node cluster configuration,  lbHost is the virtual IP address configured in Nginx and Keepalived.
-    - **lbPort**: Default port is 30089. for one node cluster configuration. For three node cluster configuration, \(haDeploymentEnabled is true\), lbPort is the Nginx API node port configured in the Nginx plugin configuration file.
-    - **lenovoPluginRootServiceUUID**: RootServiceUUID to be used by the Lenovo plugin service.
-
-    Other parameters can have default values. Optionally, you can update them with values based on your requirements. For more information on each parameter, see [Plugin configuration parameters](#plugin-configuration-parameters).
-
-7. Generate the Helm package for the Lenovo plugin on the deployment node.
-
-   1. Navigate to `odim-controller/helmcharts/lenovoplugin`.
-
-           $ cd ~/ODIM/odim-controller/helmcharts/lenovoplugin
-       
-   2. Run the following command to create `lenovoplugin` Helm package at `~/plugins/lenovoplugin`:
-
-           $ helm package lenovoplugin -d ~/plugins/lenovoplugin
-       
-       The Helm package for the Lenovo plugin is created in the tgz format.
-
-8. Save the Lenovo plugin Docker image on the deployment node at `~/plugins/lenovoplugin`.
-
-        $ sudo docker save lenovoplugin:1.0 -o ~/plugins/lenovoplugin/lenovoplugin.tar
-
-9. If it is a three-node cluster configuration, log in to each cluster node and [configure proxy server for the plugin](#configuring-proxy-server-for-a-plugin-version). 
-
-    Skip this step if it is a one-node cluster configuration.
-
-10. Navigate to the `/ODIM/odim-controller/scripts` directory on the deployment node.
-
-        $ cd ~/ODIM/odim-controller/scripts
-    
-11. Open the `kube_deploy_nodes.yaml` file.
-
-         $ vi kube_deploy_nodes.yaml
-
-12. Update the following parameters in the `kube_deploy_nodes.yaml` file to their corresponding values: 
-
-    | Parameter                    | Value                                                        |
-    | ---------------------------- | ------------------------------------------------------------ |
-    | connectionMethodConf         | The connection method associated with Lenovo: ConnectionMethodVariant: `Compute:BasicAuth:LENOVO_v1.0.0`<br> |
-    | odimraKafkaClientCertFQDNSan | The FQDN to be included in the Kafka client certificate of Resource Aggregator for ODIM for deploying Lenovo plugin: `lenovoplugin`. |
-    | odimraServerCertFQDNSan      | The FQDN to be included in the server certificate of Resource Aggregator for ODIM for deploying Lenovo: `lenovoplugin` . |
-    | odimPluginPath               | The path of the directory where the Lenovo Helm package, the `lenovoplugin` image, and the modified `lenovoplugin-config.yaml` are copied. |
-
-       Example:
-
-      ```
-      odimPluginPath: /home/bruce/plugins
-       connectionMethodConf:
-       - ConnectionMethodType: Redfish
-         ConnectionMethodVariant: Compute:BasicAuth:LENOVO_v1.0.0
-         odimraKafkaClientCertFQDNSan: lenovoplugin
-         odimraServerCertFQDNSan: lenovoplugin
-      ```
-
-13. Run the following command: 
-
-          $ python3 odim-controller.py --config /home/${USER}/ODIM/odim-controller/scripts/kube_deploy_nodes.yaml --upgrade odimra-config
-
-14. Run the following command to install the Lenovo plugin: 
-
-         $ python3 odim-controller.py --config /home/${USER}/ODIM/odim-controller/scripts/kube_deploy_nodes.yaml --add plugin --plugin lenovo plugin
-
-15. Run the following command on the cluster nodes to verify the Lenovo plugin pod is up and running: 
-
-         $ kubectl get pods -n odim
-      Example output of the Lenovo plugin pod details:
-
-    | NAME                         | READY | STATUS  | RESTARTS | AGE   |
-    | ---------------------------- | ----- | ------- | -------- | ----- |
-    | lenovoplugin-5fc4b6788-2xx97 | 1/1   | Running | 0        | 4d22h |
-
-16. [Add the Lenovo plugin into the Resource Aggregator for ODIM framework](#adding-a-plugin-into-the-resource-aggregator-for-odim-framework). 
-
 ## Deploying the Cisco ACI plugin
 
 Refer to the deployment instructions of the Cisco ACI plugin [here](https://github.com/ODIM-Project/PluginCiscoACI/blob/main/README.md).
@@ -1547,21 +1426,6 @@ The plugin you want to add is successfully deployed.
    
    
    
-   **Sample request payload for adding the Lenovo plugin:** 
-   
-   ```
-   {
-      "HostName":"lenovoplugin:45009",
-      "UserName":"admin",
-      "Password":"Plug!n12$4",
-   "Links":{
-               "ConnectionMethod": {
-                 "@odata.id": "/redfish/v1/AggregationService/ConnectionMethods/d172e66c-b4a8-437c-981b-1c07ddfeacaa"
-             }
-       }
-    }
-   ```
-   
     **Request payload parameters** 
    
    |Parameter|Type|Description|
@@ -1575,7 +1439,6 @@ The plugin you want to add is successfully deployed.
    |------|----------------|----------------|------|
    |GRF plugin|admin|GRFPlug!n12$4|Compute:BasicAuth:GRF\_v1.0.0|
    |URP|admin|Plug!n12$4|Compute:BasicAuth:URP\_v1.0.0|
-   |Lenovo plugin|admin|Plug!n12$4|Compute:BasicAuth:LENOVO_v1.0.0|
    
     Use the following curl command to add the plugin:
    
@@ -3428,7 +3291,6 @@ The following table lists all the default ports used by the resource aggregator,
 |GRF plugin port|45001|
 |URP port|45007|
 |Dell port|45005|
-|Lenovo port|45009|
 
 ## Deploying the GRF plugin
 


### PR DESCRIPTION
Removed all instances of Lenovo from the Getting Started Readme on upstream dev branch as requested by the team.