### PR TITLE
odim:4875 : Added attribute capacity GB for drives

### DIFF
--- a/lib-dmtf/model/storage.go
+++ b/lib-dmtf/model/storage.go
@@ -158,7 +158,8 @@ type Drive struct {
 	AssetTag                      string             `json:"AssetTag,omitempty"`
 	BlockSizeBytes                int                `json:"BlockSizeBytes,omitempty"`
 	CapableSpeedGbs               int                `json:"CapableSpeedGbs,omitempty"`
-	CapacityBytes                 int                `json:"CapacityBytes,omitempty"`
+	CapacityGB                    int                `json:"CapacityGB,omitempty"`
+        CapacityBytes                 int                `json:"CapacityBytes,omitempty"`
 	Description                   string             `json:"Description,omitempty"`
 	EncryptionAbility             string             `json:"EncryptionAbility,omitempty"`
 	EncryptionStatus              string             `json:"EncryptionStatus,omitempty"`

--- a/lib-dmtf/model/storage.go
+++ b/lib-dmtf/model/storage.go
@@ -159,7 +159,7 @@ type Drive struct {
 	BlockSizeBytes                int                `json:"BlockSizeBytes,omitempty"`
 	CapableSpeedGbs               int                `json:"CapableSpeedGbs,omitempty"`
 	CapacityGB                    int                `json:"CapacityGB,omitempty"`
-        CapacityBytes                 int                `json:"CapacityBytes,omitempty"`
+	CapacityBytes                 int                `json:"CapacityBytes,omitempty"`
 	Description                   string             `json:"Description,omitempty"`
 	EncryptionAbility             string             `json:"EncryptionAbility,omitempty"`
 	EncryptionStatus              string             `json:"EncryptionStatus,omitempty"`


### PR DESCRIPTION
Adding capacityGB in struct for iloplugin to calculate capacitybytes from capacityGB instead of capacityMiB