### PR TITLE
odim-6497: Add omitempty for odatatype in storage controller struct

### DIFF
--- a/lib-dmtf/model/storage.go
+++ b/lib-dmtf/model/storage.go
@@ -47,7 +47,7 @@ type StorageControllers struct {
 	Oid                          string                    `json:"@odata.id"`
 	ODataContext                 string                    `json:"@odata.context,omitempty"`
 	ODataEtag                    string                    `json:"@odata.etag,omitempty"`
-	ODataType                    string                    `json:"@odata.type"`
+	ODataType                    string                    `json:"@odata.type,omitempty"`
 	AssetTag                     string                    `json:"AssetTag,omitempty"`
 	FirmwareVersion              string                    `json:"FirmwareVersion,omitempty"`
 	Manufacturer                 string                    `json:"Manufacturer,omitempty"`


### PR DESCRIPTION
Add omitempty for odatatype in storage controller struct