### PR TITLE
odim-6496: Modify datatype for location under Port struct

### DIFF
--- a/lib-dmtf/model/port.go
+++ b/lib-dmtf/model/port.go
@@ -54,7 +54,7 @@ type Port struct {
 	EnvironmentMetrics      *Link                `json:"EnvironmentMetrics,omitempty"`
 	FunctionMaxBandwidth    []*FunctionBandwidth `json:"FunctionMaxBandwidth,omitempty"`
 	FunctionMinBandwidth    []*FunctionBandwidth `json:"FunctionMinBandwidth,omitempty"`
-	Location                *Link                `json:"Location,omitempty"`
+	Location                interface{}          `json:"Location,omitempty"`
 	SFP                     SFP                  `json:"SFP,omitempty"`
 }
 


### PR DESCRIPTION
Modify datatype for location under Port struct