### PR TITLE
Sprint-63-odim-6794: Redis DB Sync issue Fixed 

### DIFF
--- a/build/Redis/6379.conf
+++ b/build/Redis/6379.conf
@@ -1205,7 +1205,7 @@ activerehashing yes
 #
 # Both the hard or the soft limit can be disabled by setting them to zero.
 client-output-buffer-limit normal 0 0 0
-client-output-buffer-limit replica 256mb 64mb 60
+client-output-buffer-limit replica 512mb 512mb 60
 client-output-buffer-limit pubsub 32mb 8mb 60
 
 # Client query buffers accumulate new commands. They are limited to a fixed

--- a/build/Redis/6380.conf
+++ b/build/Redis/6380.conf
@@ -1205,7 +1205,7 @@ activerehashing yes
 #
 # Both the hard or the soft limit can be disabled by setting them to zero.
 client-output-buffer-limit normal 0 0 0
-client-output-buffer-limit replica 256mb 64mb 60
+client-output-buffer-limit replica 512mb 512mb 60
 client-output-buffer-limit pubsub 32mb 8mb 60
 
 # Client query buffers accumulate new commands. They are limited to a fixed

--- a/install/Docker/dockerfiles/scripts/redis-master.conf
+++ b/install/Docker/dockerfiles/scripts/redis-master.conf
@@ -224,7 +224,7 @@ dir /redis-data
 # starting the replication synchronization process, otherwise the master will
 # refuse the slave request.
 #
-#masterauth REDIS_DEFAULT_PASSWORD
+ masterauth REDIS_DEFAULT_PASSWORD
 
 # When a slave loses its connection with the master, or when the replication
 # is still in progress, the slave can act in two different ways:
@@ -815,7 +815,7 @@ activerehashing yes
 #
 # Both the hard or the soft limit can be disabled by setting them to zero.
 client-output-buffer-limit normal 0 0 0
-client-output-buffer-limit slave 256mb 64mb 60
+client-output-buffer-limit slave 512mb 512mb 60
 client-output-buffer-limit pubsub 32mb 8mb 60
 
 # Redis calls an internal function to perform many background tasks, like

--- a/install/Docker/dockerfiles/scripts/redis-slave.conf
+++ b/install/Docker/dockerfiles/scripts/redis-slave.conf
@@ -815,7 +815,7 @@ activerehashing yes
 #
 # Both the hard or the soft limit can be disabled by setting them to zero.
 client-output-buffer-limit normal 0 0 0
-client-output-buffer-limit slave 256mb 64mb 60
+client-output-buffer-limit slave 512mb 512mb 60
 client-output-buffer-limit pubsub 32mb 8mb 60
 
 # Redis calls an internal function to perform many background tasks, like

--- a/odim-controller/helmcharts/redis-ha/values.yaml
+++ b/odim-controller/helmcharts/redis-ha/values.yaml
@@ -7,8 +7,8 @@ odimra:
   redisSecondayReplicaCount: 2
   redisMasterSet: primaryset
   redisQuorum: 2
-  redisDownAfterMilliseconds: 1000
-  redisFailoverTimeout: 3000
+  redisDownAfterMilliseconds: 60000
+  redisFailoverTimeout: 180000
   redisParallelSyncs: 1
   redisInMemoryPassword:
   redisOnDiskPassword:

--- a/odim-controller/helmcharts/redis-ha/values.yaml
+++ b/odim-controller/helmcharts/redis-ha/values.yaml
@@ -8,7 +8,7 @@ odimra:
   redisMasterSet: primaryset
   redisQuorum: 2
   redisDownAfterMilliseconds: 60000
-  redisFailoverTimeout: 180000
+  redisFailoverTimeout: 60000
   redisParallelSyncs: 1
   redisInMemoryPassword:
   redisOnDiskPassword:


### PR DESCRIPTION
Fixes for DB sync issue
Changed the client-output-buffer-limit
Changed the sentinel configuration values
 
