### PR TITLE
BRUCE-6903 - fixed connection pool exhausted bug in queuing task update implementation

### DIFF
--- a/lib-persistence-manager/persistencemgr/redis.go
+++ b/lib-persistence-manager/persistencemgr/redis.go
@@ -59,6 +59,7 @@ const (
 // Conn contains the write connection instance retrieved from the connection pool
 type Conn struct {
 	WriteConn redis.Conn
+	WritePool **redis.Pool
 }
 
 //RedisExternalCalls containes the methods to make calls to external client libraries of Redis DB
@@ -175,7 +176,7 @@ func (p *ConnPool) setWritePool(c *Config) error {
 func retryForMasterIP(pool *ConnPool, config *Config) (currentMasterIP, currentMasterPort string) {
 	for i := 0; i < 120; i++ {
 		currentMasterIP, currentMasterPort = GetCurrentMasterHostPort(config)
-		if currentMasterIP != "" && pool.MasterIP != currentMasterIP {
+		if currentMasterIP != "" {
 			break
 		}
 		time.Sleep(1 * time.Second)
@@ -307,6 +308,7 @@ func (p *ConnPool) GetWriteConnection() (*Conn, *errors.Error) {
 	writeConn := writePool.Get()
 	return &Conn{
 		WriteConn: writeConn,
+		WritePool: &p.WritePool,
 	}, nil
 }
 
@@ -714,6 +716,9 @@ func (c *Conn) Ping() *errors.Error {
 func (c *Conn) IsBadConn() bool {
 	if c.WriteConn != nil && c.Ping() == nil {
 		return false
+	}
+	if c.WritePool != nil {
+		atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(c.WritePool)), nil)
 	}
 	return true
 }

--- a/odim-controller/helmcharts/redis-ha/values.yaml
+++ b/odim-controller/helmcharts/redis-ha/values.yaml
@@ -7,8 +7,8 @@ odimra:
   redisSecondayReplicaCount: 2
   redisMasterSet: primaryset
   redisQuorum: 2
-  redisDownAfterMilliseconds: 60000
-  redisFailoverTimeout: 60000
+  redisDownAfterMilliseconds: 1000
+  redisFailoverTimeout: 3000
   redisParallelSyncs: 1
   redisInMemoryPassword:
   redisOnDiskPassword:


### PR DESCRIPTION
**Changes**
- The write pool instance is made nil while closing the connection to DB because of the DB connection issue. Next time, a new connection will be retrieved from the new write pool instance.
- Removed condition to check the previous master IP is not the new master IP while resetting DB write connection as we are getting master hostname from the sentinel. Connecting to DB using hostname is introduced when TLS authentication is introduced in REDIS