### PR TITLE
Adding log labels to ODIM Pods & Removing the redirection of logs to file  and printing the logs to console

### DIFF
--- a/install/Docker/dockerfiles/scripts/start_account_session.sh
+++ b/install/Docker/dockerfiles/scripts/start_account_session.sh
@@ -48,7 +48,6 @@ start_account_session()
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/account-session-add-hosts.log 2>&1 &
 
-        tail -f /var/log/odimra_logs/account_session.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_account_session.sh
+++ b/install/Docker/dockerfiles/scripts/start_account_session.sh
@@ -47,6 +47,8 @@ start_account_session()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/account-session-add-hosts.log 2>&1 &
+
+        tail -f /var/log/odimra_logs/account_session.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_account_session.sh
+++ b/install/Docker/dockerfiles/scripts/start_account_session.sh
@@ -42,7 +42,7 @@ start_account_session()
 {
 	registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	nohup /bin/svc-account-session --registry=etcd --registry_address=${registry_address} --server_address=account-session:45101   --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/account_session.log 2>&1 &
+	/bin/svc-account-session --registry=etcd --registry_address=${registry_address} --server_address=account-session:45101   --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")` 2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_account_session.sh
+++ b/install/Docker/dockerfiles/scripts/start_account_session.sh
@@ -42,7 +42,8 @@ start_account_session()
 {
 	registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	/bin/svc-account-session --registry=etcd --registry_address=${registry_address} --server_address=account-session:45101   --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")` 2>&1 &
+        client_request_timeout=$(echo $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " " )s)
+        /bin/svc-account-session --registry=etcd --registry_address=${registry_address} --server_address=account-session:45101   --client_request_timeout=${client_request_timeout} 2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_aggregation.sh
+++ b/install/Docker/dockerfiles/scripts/start_aggregation.sh
@@ -47,6 +47,7 @@ start_aggregation()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/aggregation-add-hosts.log 2>&1 &
+        tail -f /var/log/odimra_logs/aggregation.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_aggregation.sh
+++ b/install/Docker/dockerfiles/scripts/start_aggregation.sh
@@ -47,7 +47,6 @@ start_aggregation()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/aggregation-add-hosts.log 2>&1 &
-        tail -f /var/log/odimra_logs/aggregation.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_aggregation.sh
+++ b/install/Docker/dockerfiles/scripts/start_aggregation.sh
@@ -42,7 +42,7 @@ start_aggregation()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	nohup /bin/svc-aggregation  --registry=etcd --registry_address=${registry_address} --server_address=aggregation:45102 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/aggregation.log 2>&1 &
+	nohup /bin/svc-aggregation  --registry=etcd --registry_address=${registry_address} --server_address=aggregation:45102 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s  2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_aggregation.sh
+++ b/install/Docker/dockerfiles/scripts/start_aggregation.sh
@@ -42,7 +42,7 @@ start_aggregation()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	nohup /bin/svc-aggregation  --registry=etcd --registry_address=${registry_address} --server_address=aggregation:45102 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s  2>&1 &
+        /bin/svc-aggregation  --registry=etcd --registry_address=${registry_address} --server_address=aggregation:45102 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s  2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_aggregation.sh
+++ b/install/Docker/dockerfiles/scripts/start_aggregation.sh
@@ -42,7 +42,8 @@ start_aggregation()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-        /bin/svc-aggregation  --registry=etcd --registry_address=${registry_address} --server_address=aggregation:45102 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s  2>&1 &
+        client_request_timeout=$(echo $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " " )s)
+        /bin/svc-aggregation  --registry=etcd --registry_address=${registry_address} --server_address=aggregation:45102 --client_request_timeout=${client_request_timeout} 2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_api.sh
+++ b/install/Docker/dockerfiles/scripts/start_api.sh
@@ -42,7 +42,8 @@ start_api()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	/bin/svc-api --registry=etcd --registry_address=${registry_address} --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s 2>&1 &
+	client_request_timeout=$(echo $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " " )s)
+	/bin/svc-api --registry=etcd --registry_address=${registry_address} --client_request_timeout=${client_request_timeout} 2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_api.sh
+++ b/install/Docker/dockerfiles/scripts/start_api.sh
@@ -42,7 +42,8 @@ start_api()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	nohup /bin/svc-api --registry=etcd --registry_address=${registry_address} --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/api.log 2>&1 &
+	/bin/svc-api --registry=etcd --registry_address=${registry_address} --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s 2>&1 &
+	PID=$!
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/api-add-hosts.log 2>&1 &

--- a/install/Docker/dockerfiles/scripts/start_api.sh
+++ b/install/Docker/dockerfiles/scripts/start_api.sh
@@ -47,7 +47,6 @@ start_api()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/api-add-hosts.log 2>&1 &
-	tail -f /var/log/odimra_logs/api.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_api.sh
+++ b/install/Docker/dockerfiles/scripts/start_api.sh
@@ -43,10 +43,10 @@ start_api()
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
 	nohup /bin/svc-api --registry=etcd --registry_address=${registry_address} --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/api.log 2>&1 &
-	PID=$!
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/api-add-hosts.log 2>&1 &
+	tail -f /var/log/odimra_logs/api.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_dellplugin.sh
+++ b/install/Docker/dockerfiles/scripts/start_dellplugin.sh
@@ -47,7 +47,6 @@ start_dellplugin()
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/dellplugin_logs/add-hosts.log 2>&1 &
 
-	tail -f /var/log/dellplugin_logs/dellplugin.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_dellplugin.sh
+++ b/install/Docker/dockerfiles/scripts/start_dellplugin.sh
@@ -41,7 +41,7 @@ run_forever()
 start_dellplugin()
 {
 	export PLUGIN_CONFIG_FILE_PATH=/etc/dellplugin_config/config.json
-	nohup /bin/plugin-dell >> /var/log/dellplugin_logs/dellplugin.log 2>&1 &
+	/bin/plugin-dell 2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_dellplugin.sh
+++ b/install/Docker/dockerfiles/scripts/start_dellplugin.sh
@@ -46,6 +46,8 @@ start_dellplugin()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/dellplugin_logs/add-hosts.log 2>&1 &
+
+	tail -f /var/log/dellplugin_logs/dellplugin.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_events.sh
+++ b/install/Docker/dockerfiles/scripts/start_events.sh
@@ -48,7 +48,6 @@ start_event()
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/events-add-hosts.log 2>&1 &
 
-	tail -f /var/log/odimra_logs/events.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_events.sh
+++ b/install/Docker/dockerfiles/scripts/start_events.sh
@@ -47,6 +47,8 @@ start_event()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/events-add-hosts.log 2>&1 &
+
+	tail -f /var/log/odimra_logs/events.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_events.sh
+++ b/install/Docker/dockerfiles/scripts/start_events.sh
@@ -42,7 +42,8 @@ start_event()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	/bin/svc-events --registry=etcd --registry_address=${registry_address} --server_address=events:45103  --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s  2>&1 &
+	client_request_timeout=$(echo $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " " )s)
+	/bin/svc-events --registry=etcd --registry_address=${registry_address} --server_address=events:45103  --client_request_timeout=${client_request_timeout} 2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_events.sh
+++ b/install/Docker/dockerfiles/scripts/start_events.sh
@@ -42,7 +42,7 @@ start_event()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	nohup /bin/svc-events --registry=etcd --registry_address=${registry_address} --server_address=events:45103  --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/events.log 2>&1 &
+	/bin/svc-events --registry=etcd --registry_address=${registry_address} --server_address=events:45103  --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s  2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_fabrics.sh
+++ b/install/Docker/dockerfiles/scripts/start_fabrics.sh
@@ -48,7 +48,6 @@ start_fabrics()
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/fabrics-add-hosts.log 2>&1 &
 
-        tail -f /var/log/odimra_logs/fabrics.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_fabrics.sh
+++ b/install/Docker/dockerfiles/scripts/start_fabrics.sh
@@ -42,7 +42,8 @@ start_fabrics()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	/bin/svc-fabrics  --registry=etcd --registry_address=${registry_address} --server_address=fabrics:45106 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s  2>&1 &
+        client_request_timeout=$(echo $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " " )s)
+	/bin/svc-fabrics  --registry=etcd --registry_address=${registry_address} --server_address=fabrics:45106 --client_request_timeout=${client_request_timeout} 2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_fabrics.sh
+++ b/install/Docker/dockerfiles/scripts/start_fabrics.sh
@@ -47,6 +47,8 @@ start_fabrics()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/fabrics-add-hosts.log 2>&1 &
+
+        tail -f /var/log/odimra_logs/fabrics.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_fabrics.sh
+++ b/install/Docker/dockerfiles/scripts/start_fabrics.sh
@@ -42,7 +42,7 @@ start_fabrics()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	nohup /bin/svc-fabrics  --registry=etcd --registry_address=${registry_address} --server_address=fabrics:45106 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/fabrics.log 2>&1 &
+	/bin/svc-fabrics  --registry=etcd --registry_address=${registry_address} --server_address=fabrics:45106 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s  2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_grfplugin.sh
+++ b/install/Docker/dockerfiles/scripts/start_grfplugin.sh
@@ -46,7 +46,6 @@ start_grfplugin()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/grfplugin_logs/add-hosts.log 2>&1 &
-        tail -f /var/log/grfplugin_logs/grfplugin.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_grfplugin.sh
+++ b/install/Docker/dockerfiles/scripts/start_grfplugin.sh
@@ -46,6 +46,7 @@ start_grfplugin()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/grfplugin_logs/add-hosts.log 2>&1 &
+        tail -f /var/log/grfplugin_logs/grfplugin.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_grfplugin.sh
+++ b/install/Docker/dockerfiles/scripts/start_grfplugin.sh
@@ -41,7 +41,7 @@ run_forever()
 start_grfplugin()
 {
 	export PLUGIN_CONFIG_FILE_PATH=/etc/grfplugin_config/config.json
-	nohup /bin/plugin-redfish >> /var/log/grfplugin_logs/grfplugin.log 2>&1 &
+	/bin/plugin-redfish 2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_lenovoplugin.sh
+++ b/install/Docker/dockerfiles/scripts/start_lenovoplugin.sh
@@ -46,6 +46,7 @@ start_lenovoplugin()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/lenovoplugin_logs/add-hosts.log 2>&1 &
+        tail -f /var/log/lenovoplugin_logs/lenovoplugin.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_lenovoplugin.sh
+++ b/install/Docker/dockerfiles/scripts/start_lenovoplugin.sh
@@ -41,7 +41,7 @@ run_forever()
 start_lenovoplugin()
 {
 	export PLUGIN_CONFIG_FILE_PATH=/etc/lenovoplugin_config/config.json
-	nohup /bin/plugin-lenovo >> /var/log/lenovoplugin_logs/lenovoplugin.log 2>&1 &
+	/bin/plugin-lenovo 2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_lenovoplugin.sh
+++ b/install/Docker/dockerfiles/scripts/start_lenovoplugin.sh
@@ -46,7 +46,6 @@ start_lenovoplugin()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/lenovoplugin_logs/add-hosts.log 2>&1 &
-        tail -f /var/log/lenovoplugin_logs/lenovoplugin.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_licenses.sh
+++ b/install/Docker/dockerfiles/scripts/start_licenses.sh
@@ -47,6 +47,7 @@ start_licenses()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/licenses-add-hosts.log 2>&1 &
+        tail -f /var/log/odimra_logs/licenses.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_licenses.sh
+++ b/install/Docker/dockerfiles/scripts/start_licenses.sh
@@ -42,7 +42,7 @@ start_licenses()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	nohup /bin/svc-licenses --registry=etcd --registry_address=${registry_address} --server_address=licenses:45113   --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/licenses.log 2>&1 &
+	/bin/svc-licenses --registry=etcd --registry_address=${registry_address} --server_address=licenses:45113   --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s  2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_licenses.sh
+++ b/install/Docker/dockerfiles/scripts/start_licenses.sh
@@ -47,7 +47,6 @@ start_licenses()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/licenses-add-hosts.log 2>&1 &
-        tail -f /var/log/odimra_logs/licenses.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_licenses.sh
+++ b/install/Docker/dockerfiles/scripts/start_licenses.sh
@@ -42,7 +42,8 @@ start_licenses()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	/bin/svc-licenses --registry=etcd --registry_address=${registry_address} --server_address=licenses:45113   --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s  2>&1 &
+        client_request_timeout=$(echo $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " " )s)
+	/bin/svc-licenses --registry=etcd --registry_address=${registry_address} --server_address=licenses:45113   --client_request_timeout=${client_request_timeout} 2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_managers.sh
+++ b/install/Docker/dockerfiles/scripts/start_managers.sh
@@ -42,7 +42,7 @@ start_manager()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	nohup /bin/svc-managers --registry=etcd --registry_address=${registry_address} --server_address=managers:45107  --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/managers.log 2>&1 &
+	/bin/svc-managers --registry=etcd --registry_address=${registry_address} --server_address=managers:45107  --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s 2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_managers.sh
+++ b/install/Docker/dockerfiles/scripts/start_managers.sh
@@ -47,7 +47,6 @@ start_manager()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/managers-add-hosts.log 2>&1 &
-        tail -f /var/log/odimra_logs/managers.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_managers.sh
+++ b/install/Docker/dockerfiles/scripts/start_managers.sh
@@ -47,6 +47,7 @@ start_manager()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/managers-add-hosts.log 2>&1 &
+        tail -f /var/log/odimra_logs/managers.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_managers.sh
+++ b/install/Docker/dockerfiles/scripts/start_managers.sh
@@ -42,7 +42,8 @@ start_manager()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	/bin/svc-managers --registry=etcd --registry_address=${registry_address} --server_address=managers:45107  --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s 2>&1 &
+        client_request_timeout=$(echo $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " " )s)
+	/bin/svc-managers --registry=etcd --registry_address=${registry_address} --server_address=managers:45107  --client_request_timeout=${client_request_timeout} 2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_systems.sh
+++ b/install/Docker/dockerfiles/scripts/start_systems.sh
@@ -42,7 +42,8 @@ start_systems()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	/bin/svc-systems --registry=etcd --registry_address=${registry_address} --server_address=systems:45104   --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s  2>&1 &
+        client_request_timeout=$(echo $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " " )s)
+	/bin/svc-systems --registry=etcd --registry_address=${registry_address} --server_address=systems:45104   --client_request_timeout=${client_request_timeout} 2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_systems.sh
+++ b/install/Docker/dockerfiles/scripts/start_systems.sh
@@ -42,7 +42,7 @@ start_systems()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	nohup /bin/svc-systems --registry=etcd --registry_address=${registry_address} --server_address=systems:45104   --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/systems.log 2>&1 &
+	/bin/svc-systems --registry=etcd --registry_address=${registry_address} --server_address=systems:45104   --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s  2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_systems.sh
+++ b/install/Docker/dockerfiles/scripts/start_systems.sh
@@ -47,7 +47,6 @@ start_systems()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/systems-add-hosts.log 2>&1 &
-        tail -f /var/log/odimra_logs/systems.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_systems.sh
+++ b/install/Docker/dockerfiles/scripts/start_systems.sh
@@ -47,6 +47,7 @@ start_systems()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/systems-add-hosts.log 2>&1 &
+        tail -f /var/log/odimra_logs/systems.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_task.sh
+++ b/install/Docker/dockerfiles/scripts/start_task.sh
@@ -47,7 +47,6 @@ start_task()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/task-add-hosts.log 2>&1 &
-        tail -f /var/log/odimra_logs/task.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_task.sh
+++ b/install/Docker/dockerfiles/scripts/start_task.sh
@@ -42,7 +42,7 @@ start_task()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	nohup /bin/svc-task --registry=etcd --registry_address=${registry_address} --server_address=task:45105  --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/task.log 2>&1 &
+	/bin/svc-task --registry=etcd --registry_address=${registry_address} --server_address=task:45105  --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s  2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_task.sh
+++ b/install/Docker/dockerfiles/scripts/start_task.sh
@@ -42,7 +42,8 @@ start_task()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	/bin/svc-task --registry=etcd --registry_address=${registry_address} --server_address=task:45105  --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s  2>&1 &
+        client_request_timeout=$(echo $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " " )s)
+	/bin/svc-task --registry=etcd --registry_address=${registry_address} --server_address=task:45105  --client_request_timeout=${client_request_timeout} 2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_task.sh
+++ b/install/Docker/dockerfiles/scripts/start_task.sh
@@ -47,6 +47,7 @@ start_task()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/task-add-hosts.log 2>&1 &
+        tail -f /var/log/odimra_logs/task.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_telemetry.sh
+++ b/install/Docker/dockerfiles/scripts/start_telemetry.sh
@@ -47,6 +47,7 @@ start_telemetry()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/telemetry-add-hosts.log 2>&1 &
+        tail -f /var/log/odimra_logs/telemetry.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_telemetry.sh
+++ b/install/Docker/dockerfiles/scripts/start_telemetry.sh
@@ -47,7 +47,6 @@ start_telemetry()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/telemetry-add-hosts.log 2>&1 &
-        tail -f /var/log/odimra_logs/telemetry.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_telemetry.sh
+++ b/install/Docker/dockerfiles/scripts/start_telemetry.sh
@@ -42,7 +42,7 @@ start_telemetry()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	nohup /bin/svc-telemetry  --registry=etcd --registry_address=${registry_address} --server_address=telemetry:45111 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/telemetry.log 2>&1 &
+	/bin/svc-telemetry  --registry=etcd --registry_address=${registry_address} --server_address=telemetry:45111 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s 2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_telemetry.sh
+++ b/install/Docker/dockerfiles/scripts/start_telemetry.sh
@@ -42,7 +42,8 @@ start_telemetry()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	/bin/svc-telemetry  --registry=etcd --registry_address=${registry_address} --server_address=telemetry:45111 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s 2>&1 &
+        client_request_timeout=$(echo $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " " )s)
+	/bin/svc-telemetry  --registry=etcd --registry_address=${registry_address} --server_address=telemetry:45111 --client_request_timeout=${client_request_timeout} 2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_update.sh
+++ b/install/Docker/dockerfiles/scripts/start_update.sh
@@ -47,7 +47,6 @@ start_update()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/update-add-hosts.log 2>&1 &
-        tail -f /var/log/odimra_logs/update.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_update.sh
+++ b/install/Docker/dockerfiles/scripts/start_update.sh
@@ -42,7 +42,7 @@ start_update()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	nohup /bin/svc-update  --registry=etcd --registry_address=${registry_address} --server_address=update:45108 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s >> /var/log/odimra_logs/update.log 2>&1 &
+	/bin/svc-update  --registry=etcd --registry_address=${registry_address} --server_address=update:45108 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s  2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_update.sh
+++ b/install/Docker/dockerfiles/scripts/start_update.sh
@@ -42,7 +42,8 @@ start_update()
 {
         registry_address="etcd:2379"
 	export CONFIG_FILE_PATH=/etc/odimra_config/odimra_config.json
-	/bin/svc-update  --registry=etcd --registry_address=${registry_address} --server_address=update:45108 --client_request_timeout=`expr $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " ")`s  2>&1 &
+        client_request_timeout=$(echo $(cat $CONFIG_FILE_PATH | grep SouthBoundRequestTimeoutInSecs | cut -d : -f2 | cut -d , -f1 | tr -d " " )s)
+	/bin/svc-update  --registry=etcd --registry_address=${registry_address} --server_address=update:45108 --client_request_timeout=${client_request_timeout} 2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_update.sh
+++ b/install/Docker/dockerfiles/scripts/start_update.sh
@@ -47,6 +47,7 @@ start_update()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/odimra_logs/update-add-hosts.log 2>&1 &
+        tail -f /var/log/odimra_logs/update.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_urplugin.sh
+++ b/install/Docker/dockerfiles/scripts/start_urplugin.sh
@@ -46,6 +46,7 @@ start_urplugin()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/urplugin_logs/add-hosts.log 2>&1 &
+        tail -f /var/log/urplugin_logs/urplugin.log
 }
 
 monitor_process()

--- a/install/Docker/dockerfiles/scripts/start_urplugin.sh
+++ b/install/Docker/dockerfiles/scripts/start_urplugin.sh
@@ -41,7 +41,7 @@ run_forever()
 start_urplugin()
 {
 	export PLUGIN_CONFIG_FILE_PATH=/etc/urplugin_config/config.yaml
-	nohup /bin/plugin-unmanaged-racks >> /var/log/urplugin_logs/urplugin.log 2>&1 &
+	/bin/plugin-unmanaged-racks 2>&1 &
 	PID=$!
 	sleep 3
 

--- a/install/Docker/dockerfiles/scripts/start_urplugin.sh
+++ b/install/Docker/dockerfiles/scripts/start_urplugin.sh
@@ -46,7 +46,6 @@ start_urplugin()
 	sleep 3
 
 	nohup /bin/add-hosts -file /tmp/host.append >> /var/log/urplugin_logs/add-hosts.log 2>&1 &
-        tail -f /var/log/urplugin_logs/urplugin.log
 }
 
 monitor_process()

--- a/odim-controller/helmcharts/account-session/templates/deployment.yaml
+++ b/odim-controller/helmcharts/account-session/templates/deployment.yaml
@@ -17,12 +17,12 @@ spec:
         {{- if eq .Values.odimra.deploymentType "K8S" }}
         kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
         kubernetes.labels.hpe_com_stack: authorization
-        kubernetes.labels.hpe_com_component: odim-privileges
+        kubernetes.labels.hpe_com_component: account-session
         kubernetes.labels.hpe_com_app: account-session
         {{- else if .Values.odimra.deploymentType "RHOCP"}}
         kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
         kubernetes.flat_labels.hpe_com/stack: authorization
-        kubernetes.flat_labels.hpe_com/component: odim-privileges
+        kubernetes.flat_labels.hpe_com/component: account-session
         kubernetes.flat_labels.hpe_com/app : account-session
       name: dapi-envars-fieldref
       annotations:

--- a/odim-controller/helmcharts/account-session/templates/deployment.yaml
+++ b/odim-controller/helmcharts/account-session/templates/deployment.yaml
@@ -14,6 +14,16 @@ spec:
     metadata:
       labels:
         app: account-session
+        {{- if eq .Values.odimra.deploymentType "K8S" }}
+        kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+        kubernetes.labels.hpe_com_stack: authorization
+        kubernetes.labels.hpe_com_component: odim-privileges
+        kubernetes.labels.hpe_com_app: account-session
+        {{- else if .Values.odimra.deploymentType "RHOCP"}}
+        kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+        kubernetes.flat_labels.hpe_com/stack: authorization
+        kubernetes.flat_labels.hpe_com/component: odim-privileges
+        kubernetes.flat_labels.hpe_com/app : account-session
       name: dapi-envars-fieldref
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}

--- a/odim-controller/helmcharts/account-session/templates/deployment.yaml
+++ b/odim-controller/helmcharts/account-session/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         kubernetes.flat_labels.hpe_com/stack: authorization
         kubernetes.flat_labels.hpe_com/component: account-session
         kubernetes.flat_labels.hpe_com/app : account-session
+        {{- end }}
       name: dapi-envars-fieldref
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}

--- a/odim-controller/helmcharts/account-session/values.yaml
+++ b/odim-controller/helmcharts/account-session/values.yaml
@@ -3,3 +3,4 @@ odimra:
   groupID:
   haDeploymentEnabled:
   accountSessionImageTag: "4.0"
+  deploymentType: "RHOCP"

--- a/odim-controller/helmcharts/account-session/values.yaml
+++ b/odim-controller/helmcharts/account-session/values.yaml
@@ -3,4 +3,4 @@ odimra:
   groupID:
   haDeploymentEnabled:
   accountSessionImageTag: "4.0"
-  deploymentType: "RHOCP"
+  deploymentType: "K8S"

--- a/odim-controller/helmcharts/aggregation/templates/deployment.yaml
+++ b/odim-controller/helmcharts/aggregation/templates/deployment.yaml
@@ -14,6 +14,16 @@ spec:
     metadata:
       labels:
         app: aggregation
+        {{- if eq .Values.odimra.deploymentType "K8S" }}
+        kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+        kubernetes.labels.hpe_com_stack: process
+        kubernetes.labels.hpe_com_component: aggregation
+        kubernetes.labels.hpe_com_app: aggregation
+        {{- else if .Values.odimra.deploymentType "RHOCP"}}
+        kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+        kubernetes.flat_labels.hpe_com/stack: process
+        kubernetes.flat_labels.hpe_com/component: aggregation
+        kubernetes.flat_labels.hpe_com/app : aggregation
       name: dapi-envars-fieldref
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}

--- a/odim-controller/helmcharts/aggregation/templates/deployment.yaml
+++ b/odim-controller/helmcharts/aggregation/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         kubernetes.flat_labels.hpe_com/stack: process
         kubernetes.flat_labels.hpe_com/component: aggregation
         kubernetes.flat_labels.hpe_com/app : aggregation
+        {{- end }}
       name: dapi-envars-fieldref
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}

--- a/odim-controller/helmcharts/aggregation/values.yaml
+++ b/odim-controller/helmcharts/aggregation/values.yaml
@@ -3,3 +3,4 @@ odimra:
   groupID:
   haDeploymentEnabled:
   aggregationImageTag: "5.0"
+  deploymentType: "K8S"

--- a/odim-controller/helmcharts/api/templates/deployment.yaml
+++ b/odim-controller/helmcharts/api/templates/deployment.yaml
@@ -14,6 +14,17 @@ spec:
     metadata:
       labels:
         app: api
+        {{- if eq .Values.odimra.deploymentType "K8S" }}
+        kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+        kubernetes.labels.hpe_com_stack: api-gateway
+        kubernetes.labels.hpe_com_component: api
+        kubernetes.labels.hpe_com_app: api
+        {{- else if .Values.odimra.deploymentType "RHOCP"}}
+        kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+        kubernetes.flat_labels.hpe_com/stack: api-gateway
+        kubernetes.flat_labels.hpe_com/component: api
+        kubernetes.flat_labels.hpe_com/app : api
+      name: dapi-envars-fieldref
       name: dapi-envars-fieldref
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}

--- a/odim-controller/helmcharts/api/templates/deployment.yaml
+++ b/odim-controller/helmcharts/api/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         kubernetes.flat_labels.hpe_com/stack: api-gateway
         kubernetes.flat_labels.hpe_com/component: api
         kubernetes.flat_labels.hpe_com/app : api
+        {{- end }}
       name: dapi-envars-fieldref
       name: dapi-envars-fieldref
       annotations:

--- a/odim-controller/helmcharts/api/values.yaml
+++ b/odim-controller/helmcharts/api/values.yaml
@@ -4,3 +4,4 @@ odimra:
   apiNodePort:
   haDeploymentEnabled:
   apiImageTag: "5.0"
+  deploymentType: "K8S"

--- a/odim-controller/helmcharts/dellplugin/dellplugin/templates/deployment.yaml
+++ b/odim-controller/helmcharts/dellplugin/dellplugin/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
               kubernetes.flat_labels.hpe_com/stack: vendor-plugin
               kubernetes.flat_labels.hpe_com/component: dellplugin
               kubernetes.flat_labels.hpe_com/app : dellplugin
+              {{- end }}
       hostname: dellplugin
       volumes:
         - name: dellplugin-config-vol

--- a/odim-controller/helmcharts/dellplugin/dellplugin/templates/deployment.yaml
+++ b/odim-controller/helmcharts/dellplugin/dellplugin/templates/deployment.yaml
@@ -24,6 +24,16 @@ spec:
           labelSelector:
             matchLabels:
               app: dellplugin
+              {{- if eq .Values.odimra.deploymentType "K8S" }}
+              kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+              kubernetes.labels.hpe_com_stack: vendor-plugin
+              kubernetes.labels.hpe_com_component: dellplugin
+              kubernetes.labels.hpe_com_app: dellplugin
+              {{- else if .Values.odimra.deploymentType "RHOCP"}}
+              kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+              kubernetes.flat_labels.hpe_com/stack: vendor-plugin
+              kubernetes.flat_labels.hpe_com/component: dellplugin
+              kubernetes.flat_labels.hpe_com/app : dellplugin
       hostname: dellplugin
       volumes:
         - name: dellplugin-config-vol

--- a/odim-controller/helmcharts/dellplugin/dellplugin/templates/deployment.yaml
+++ b/odim-controller/helmcharts/dellplugin/dellplugin/templates/deployment.yaml
@@ -14,6 +14,17 @@ spec:
     metadata:
       labels:
         app: dellplugin
+        {{- if eq .Values.odimra.deploymentType "K8S" }}
+        kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+        kubernetes.labels.hpe_com_stack: vendor-plugin
+        kubernetes.labels.hpe_com_component: dellplugin
+        kubernetes.labels.hpe_com_app: dellplugin
+        {{- else if .Values.odimra.deploymentType "RHOCP"}}
+        kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+        kubernetes.flat_labels.hpe_com/stack: vendor-plugin
+        kubernetes.flat_labels.hpe_com/component: dellplugin
+        kubernetes.flat_labels.hpe_com/app : dellplugin
+        {{- end }}
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
     spec:
@@ -24,17 +35,6 @@ spec:
           labelSelector:
             matchLabels:
               app: dellplugin
-              {{- if eq .Values.odimra.deploymentType "K8S" }}
-              kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
-              kubernetes.labels.hpe_com_stack: vendor-plugin
-              kubernetes.labels.hpe_com_component: dellplugin
-              kubernetes.labels.hpe_com_app: dellplugin
-              {{- else if .Values.odimra.deploymentType "RHOCP"}}
-              kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
-              kubernetes.flat_labels.hpe_com/stack: vendor-plugin
-              kubernetes.flat_labels.hpe_com/component: dellplugin
-              kubernetes.flat_labels.hpe_com/app : dellplugin
-              {{- end }}
       hostname: dellplugin
       volumes:
         - name: dellplugin-config-vol

--- a/odim-controller/helmcharts/dellplugin/dellplugin/values.yaml
+++ b/odim-controller/helmcharts/dellplugin/dellplugin/values.yaml
@@ -2,6 +2,7 @@ odimra:
   namespace: 
   groupID:
   haDeploymentEnabled:
+  deploymentType: "K8S"
 dellplugin:
   eventListenerNodePort: 
   imageTag: "2.2"

--- a/odim-controller/helmcharts/events/templates/deployment.yaml
+++ b/odim-controller/helmcharts/events/templates/deployment.yaml
@@ -14,6 +14,16 @@ spec:
     metadata:
       labels:
         app: events
+        {{- if eq .Values.odimra.deploymentType "K8S" }}
+        kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+        kubernetes.labels.hpe_com_stack: events-processing
+        kubernetes.labels.hpe_com_component: events
+        kubernetes.labels.hpe_com_app: events
+        {{- else if .Values.odimra.deploymentType "RHOCP"}}
+        kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+        kubernetes.flat_labels.hpe_com/stack: events-processing
+        kubernetes.flat_labels.hpe_com/component: events
+        kubernetes.flat_labels.hpe_com/app : events
       name: dapi-envars-fieldref
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}

--- a/odim-controller/helmcharts/events/templates/deployment.yaml
+++ b/odim-controller/helmcharts/events/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         kubernetes.flat_labels.hpe_com/stack: events-processing
         kubernetes.flat_labels.hpe_com/component: events
         kubernetes.flat_labels.hpe_com/app : events
+        {{- end }}
       name: dapi-envars-fieldref
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}

--- a/odim-controller/helmcharts/events/values.yaml
+++ b/odim-controller/helmcharts/events/values.yaml
@@ -3,3 +3,4 @@ odimra:
   groupID:
   haDeploymentEnabled:
   eventImageTag: "5.0"
+  deploymentType: "K8S"

--- a/odim-controller/helmcharts/fabrics/templates/deployment.yaml
+++ b/odim-controller/helmcharts/fabrics/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
               kubernetes.flat_labels.hpe_com/stack: process
               kubernetes.flat_labels.hpe_com/component: fabrics
               kubernetes.flat_labels.hpe_com/app : fabrics
+              {{- end }}
       hostname: fabrics
       volumes:
         - name: odimra-config-vol

--- a/odim-controller/helmcharts/fabrics/templates/deployment.yaml
+++ b/odim-controller/helmcharts/fabrics/templates/deployment.yaml
@@ -14,6 +14,17 @@ spec:
     metadata:
       labels:
         app: fabrics
+        {{- if eq .Values.odimra.deploymentType "K8S" }}
+        kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+        kubernetes.labels.hpe_com_stack: process
+        kubernetes.labels.hpe_com_component: fabrics
+        kubernetes.labels.hpe_com_app: fabrics
+        {{- else if .Values.odimra.deploymentType "RHOCP"}}
+        kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+        kubernetes.flat_labels.hpe_com/stack: process
+        kubernetes.flat_labels.hpe_com/component: fabrics
+        kubernetes.flat_labels.hpe_com/app : fabrics
+        {{- end }}
       name: dapi-envars-fieldref
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
@@ -25,17 +36,6 @@ spec:
           labelSelector:
             matchLabels:
               app: fabrics 
-              {{- if eq .Values.odimra.deploymentType "K8S" }}
-              kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
-              kubernetes.labels.hpe_com_stack: process
-              kubernetes.labels.hpe_com_component: fabrics
-              kubernetes.labels.hpe_com_app: fabrics
-              {{- else if .Values.odimra.deploymentType "RHOCP"}}
-              kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
-              kubernetes.flat_labels.hpe_com/stack: process
-              kubernetes.flat_labels.hpe_com/component: fabrics
-              kubernetes.flat_labels.hpe_com/app : fabrics
-              {{- end }}
       hostname: fabrics
       volumes:
         - name: odimra-config-vol

--- a/odim-controller/helmcharts/fabrics/templates/deployment.yaml
+++ b/odim-controller/helmcharts/fabrics/templates/deployment.yaml
@@ -25,6 +25,16 @@ spec:
           labelSelector:
             matchLabels:
               app: fabrics 
+              {{- if eq .Values.odimra.deploymentType "K8S" }}
+              kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+              kubernetes.labels.hpe_com_stack: process
+              kubernetes.labels.hpe_com_component: fabrics
+              kubernetes.labels.hpe_com_app: fabrics
+              {{- else if .Values.odimra.deploymentType "RHOCP"}}
+              kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+              kubernetes.flat_labels.hpe_com/stack: process
+              kubernetes.flat_labels.hpe_com/component: fabrics
+              kubernetes.flat_labels.hpe_com/app : fabrics
       hostname: fabrics
       volumes:
         - name: odimra-config-vol

--- a/odim-controller/helmcharts/fabrics/values.yaml
+++ b/odim-controller/helmcharts/fabrics/values.yaml
@@ -3,3 +3,4 @@ odimra:
   groupID:
   haDeploymentEnabled:
   fabricsImageTag: "4.0"
+  deploymentType: "K8S"

--- a/odim-controller/helmcharts/grfplugin/grfplugin/templates/deployment.yaml
+++ b/odim-controller/helmcharts/grfplugin/grfplugin/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
-              app: grfplugin        
+              app: grfplugin
       hostname: grfplugin
       volumes:
         - name: grfplugin-config-vol

--- a/odim-controller/helmcharts/grfplugin/grfplugin/templates/deployment.yaml
+++ b/odim-controller/helmcharts/grfplugin/grfplugin/templates/deployment.yaml
@@ -14,6 +14,17 @@ spec:
     metadata:
       labels:
         app: grfplugin
+        {{- if eq .Values.odimra.deploymentType "K8S" }}
+        kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+        kubernetes.labels.hpe_com_stack: vendor-plugin
+        kubernetes.labels.hpe_com_component: grfplugin
+        kubernetes.labels.hpe_com_app: grfplugin
+        {{- else if .Values.odimra.deploymentType "RHOCP"}}
+        kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+        kubernetes.flat_labels.hpe_com/stack: vendor-plugin
+        kubernetes.flat_labels.hpe_com/component: grfplugin
+        kubernetes.flat_labels.hpe_com/app : grfplugin
+        {{- end }}
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
     spec:
@@ -24,17 +35,7 @@ spec:
           labelSelector:
             matchLabels:
               app: grfplugin
-              {{- if eq .Values.odimra.deploymentType "K8S" }}
-              kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
-              kubernetes.labels.hpe_com_stack: vendor-plugin
-              kubernetes.labels.hpe_com_component: grfplugin
-              kubernetes.labels.hpe_com_app: grfplugin
-              {{- else if .Values.odimra.deploymentType "RHOCP"}}
-              kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
-              kubernetes.flat_labels.hpe_com/stack: vendor-plugin
-              kubernetes.flat_labels.hpe_com/component: grfplugin
-              kubernetes.flat_labels.hpe_com/app : grfplugin
-              {{- end }}
+              
       hostname: grfplugin
       volumes:
         - name: grfplugin-config-vol

--- a/odim-controller/helmcharts/grfplugin/grfplugin/templates/deployment.yaml
+++ b/odim-controller/helmcharts/grfplugin/grfplugin/templates/deployment.yaml
@@ -34,8 +34,7 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
-              app: grfplugin
-              
+              app: grfplugin        
       hostname: grfplugin
       volumes:
         - name: grfplugin-config-vol

--- a/odim-controller/helmcharts/grfplugin/grfplugin/templates/deployment.yaml
+++ b/odim-controller/helmcharts/grfplugin/grfplugin/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
               kubernetes.flat_labels.hpe_com/stack: vendor-plugin
               kubernetes.flat_labels.hpe_com/component: grfplugin
               kubernetes.flat_labels.hpe_com/app : grfplugin
+              {{- end }}
       hostname: grfplugin
       volumes:
         - name: grfplugin-config-vol

--- a/odim-controller/helmcharts/grfplugin/grfplugin/templates/deployment.yaml
+++ b/odim-controller/helmcharts/grfplugin/grfplugin/templates/deployment.yaml
@@ -24,6 +24,16 @@ spec:
           labelSelector:
             matchLabels:
               app: grfplugin
+              {{- if eq .Values.odimra.deploymentType "K8S" }}
+              kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+              kubernetes.labels.hpe_com_stack: vendor-plugin
+              kubernetes.labels.hpe_com_component: grfplugin
+              kubernetes.labels.hpe_com_app: grfplugin
+              {{- else if .Values.odimra.deploymentType "RHOCP"}}
+              kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+              kubernetes.flat_labels.hpe_com/stack: vendor-plugin
+              kubernetes.flat_labels.hpe_com/component: grfplugin
+              kubernetes.flat_labels.hpe_com/app : grfplugin
       hostname: grfplugin
       volumes:
         - name: grfplugin-config-vol

--- a/odim-controller/helmcharts/grfplugin/grfplugin/values.yaml
+++ b/odim-controller/helmcharts/grfplugin/grfplugin/values.yaml
@@ -2,6 +2,7 @@ odimra:
   namespace:
   groupID:
   haDeploymentEnabled:
+  deploymentType: "K8S"
 grfplugin:
   eventListenerNodePort:
   imageTag: "3.2"

--- a/odim-controller/helmcharts/lenovoplugin/lenovoplugin/templates/deployment.yaml
+++ b/odim-controller/helmcharts/lenovoplugin/lenovoplugin/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       kubernetes.flat_labels.hpe_com/stack: vendor-plugin
       kubernetes.flat_labels.hpe_com/component: lenovoplugin
       kubernetes.flat_labels.hpe_com/app : lenovoplugin
+      {{- end }}
   template:
     metadata:
       labels:

--- a/odim-controller/helmcharts/lenovoplugin/lenovoplugin/templates/deployment.yaml
+++ b/odim-controller/helmcharts/lenovoplugin/lenovoplugin/templates/deployment.yaml
@@ -10,21 +10,21 @@ spec:
   selector:
     matchLabels:
       app: lenovoplugin
-      {{- if eq .Values.odimra.deploymentType "K8S" }}
-      kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
-      kubernetes.labels.hpe_com_stack: vendor-plugin
-      kubernetes.labels.hpe_com_component: lenovoplugin
-      kubernetes.labels.hpe_com_app: lenovoplugin
-      {{- else if .Values.odimra.deploymentType "RHOCP"}}
-      kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
-      kubernetes.flat_labels.hpe_com/stack: vendor-plugin
-      kubernetes.flat_labels.hpe_com/component: lenovoplugin
-      kubernetes.flat_labels.hpe_com/app : lenovoplugin
-      {{- end }}
   template:
     metadata:
       labels:
         app: lenovoplugin
+        {{- if eq .Values.odimra.deploymentType "K8S" }}
+        kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+        kubernetes.labels.hpe_com_stack: vendor-plugin
+        kubernetes.labels.hpe_com_component: lenovoplugin
+        kubernetes.labels.hpe_com_app: lenovoplugin
+        {{- else if .Values.odimra.deploymentType "RHOCP"}}
+        kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+        kubernetes.flat_labels.hpe_com/stack: vendor-plugin
+        kubernetes.flat_labels.hpe_com/component: lenovoplugin
+        kubernetes.flat_labels.hpe_com/app : lenovoplugin
+        {{- end }}
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
     spec:

--- a/odim-controller/helmcharts/lenovoplugin/lenovoplugin/templates/deployment.yaml
+++ b/odim-controller/helmcharts/lenovoplugin/lenovoplugin/templates/deployment.yaml
@@ -10,6 +10,16 @@ spec:
   selector:
     matchLabels:
       app: lenovoplugin
+      {{- if eq .Values.odimra.deploymentType "K8S" }}
+      kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+      kubernetes.labels.hpe_com_stack: vendor-plugin
+      kubernetes.labels.hpe_com_component: lenovoplugin
+      kubernetes.labels.hpe_com_app: lenovoplugin
+      {{- else if .Values.odimra.deploymentType "RHOCP"}}
+      kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+      kubernetes.flat_labels.hpe_com/stack: vendor-plugin
+      kubernetes.flat_labels.hpe_com/component: lenovoplugin
+      kubernetes.flat_labels.hpe_com/app : lenovoplugin
   template:
     metadata:
       labels:

--- a/odim-controller/helmcharts/lenovoplugin/lenovoplugin/values.yaml
+++ b/odim-controller/helmcharts/lenovoplugin/lenovoplugin/values.yaml
@@ -2,6 +2,7 @@ odimra:
   namespace:
   groupID:
   haDeploymentEnabled:
+  deploymentType: "K8S"
 lenovoplugin:
   hostname:
   eventListenerNodePort:

--- a/odim-controller/helmcharts/licenses/templates/deployment.yaml
+++ b/odim-controller/helmcharts/licenses/templates/deployment.yaml
@@ -34,7 +34,8 @@ spec:
               kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
               kubernetes.flat_labels.hpe_com/stack: process
               kubernetes.flat_labels.hpe_com/component: licenses
-              kubernetes.flat_labels.hpe_com/app : licenses      
+              kubernetes.flat_labels.hpe_com/app : licenses   
+              {{- end }}   
       hostname: licenses
       volumes:
         - name: odimra-config-vol

--- a/odim-controller/helmcharts/licenses/templates/deployment.yaml
+++ b/odim-controller/helmcharts/licenses/templates/deployment.yaml
@@ -23,8 +23,8 @@ spec:
         kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
         kubernetes.flat_labels.hpe_com/stack: process
         kubernetes.flat_labels.hpe_com/component: licenses
-        kubernetes.flat_labels.hpe_com/app : licenses   
-        {{- end }}  
+        kubernetes.flat_labels.hpe_com/app : licenses
+        {{- end }}
       name: dapi-envars-fieldref
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}

--- a/odim-controller/helmcharts/licenses/templates/deployment.yaml
+++ b/odim-controller/helmcharts/licenses/templates/deployment.yaml
@@ -24,7 +24,17 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
-              app: licenses      
+              app: licenses
+              {{- if eq .Values.odimra.deploymentType "K8S" }}
+              kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+              kubernetes.labels.hpe_com_stack: process
+              kubernetes.labels.hpe_com_component: licenses
+              kubernetes.labels.hpe_com_app: licenses
+              {{- else if .Values.odimra.deploymentType "RHOCP"}}
+              kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+              kubernetes.flat_labels.hpe_com/stack: process
+              kubernetes.flat_labels.hpe_com/component: licenses
+              kubernetes.flat_labels.hpe_com/app : licenses      
       hostname: licenses
       volumes:
         - name: odimra-config-vol

--- a/odim-controller/helmcharts/licenses/templates/deployment.yaml
+++ b/odim-controller/helmcharts/licenses/templates/deployment.yaml
@@ -14,6 +14,17 @@ spec:
     metadata:
       labels:
         app: licenses
+        {{- if eq .Values.odimra.deploymentType "K8S" }}
+        kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+        kubernetes.labels.hpe_com_stack: process
+        kubernetes.labels.hpe_com_component: licenses
+        kubernetes.labels.hpe_com_app: licenses
+        {{- else if .Values.odimra.deploymentType "RHOCP"}}
+        kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+        kubernetes.flat_labels.hpe_com/stack: process
+        kubernetes.flat_labels.hpe_com/component: licenses
+        kubernetes.flat_labels.hpe_com/app : licenses   
+        {{- end }}  
       name: dapi-envars-fieldref
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
@@ -24,18 +35,7 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
-              app: licenses
-              {{- if eq .Values.odimra.deploymentType "K8S" }}
-              kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
-              kubernetes.labels.hpe_com_stack: process
-              kubernetes.labels.hpe_com_component: licenses
-              kubernetes.labels.hpe_com_app: licenses
-              {{- else if .Values.odimra.deploymentType "RHOCP"}}
-              kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
-              kubernetes.flat_labels.hpe_com/stack: process
-              kubernetes.flat_labels.hpe_com/component: licenses
-              kubernetes.flat_labels.hpe_com/app : licenses   
-              {{- end }}   
+              app: licenses 
       hostname: licenses
       volumes:
         - name: odimra-config-vol

--- a/odim-controller/helmcharts/licenses/values.yaml
+++ b/odim-controller/helmcharts/licenses/values.yaml
@@ -3,3 +3,4 @@ odimra:
   groupID:
   haDeploymentEnabled:        
   licensesImageTag: "2.0"
+  deploymentType: "K8S"

--- a/odim-controller/helmcharts/managers/templates/deployment.yaml
+++ b/odim-controller/helmcharts/managers/templates/deployment.yaml
@@ -14,6 +14,16 @@ spec:
     metadata:
       labels:
         app: managers
+        {{- if eq .Values.odimra.deploymentType "K8S" }}
+        kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+        kubernetes.labels.hpe_com_stack: process
+        kubernetes.labels.hpe_com_component: managers
+        kubernetes.labels.hpe_com_app: managers
+        {{- else if .Values.odimra.deploymentType "RHOCP"}}
+        kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+        kubernetes.flat_labels.hpe_com/stack: process
+        kubernetes.flat_labels.hpe_com/component: managers
+        kubernetes.flat_labels.hpe_com/app : managers
       name: dapi-envars-fieldref
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}

--- a/odim-controller/helmcharts/managers/templates/deployment.yaml
+++ b/odim-controller/helmcharts/managers/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         kubernetes.flat_labels.hpe_com/stack: process
         kubernetes.flat_labels.hpe_com/component: managers
         kubernetes.flat_labels.hpe_com/app : managers
+        {{- end }}
       name: dapi-envars-fieldref
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}

--- a/odim-controller/helmcharts/managers/values.yaml
+++ b/odim-controller/helmcharts/managers/values.yaml
@@ -3,3 +3,4 @@ odimra:
   groupID:
   haDeploymentEnabled:        
   managersImageTag: "5.0"
+  deploymentType: "K8S"

--- a/odim-controller/helmcharts/systems/templates/deployment.yaml
+++ b/odim-controller/helmcharts/systems/templates/deployment.yaml
@@ -14,6 +14,16 @@ spec:
     metadata:
       labels:
         app: systems
+        {{- if eq .Values.odimra.deploymentType "K8S" }}
+        kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+        kubernetes.labels.hpe_com_stack: process
+        kubernetes.labels.hpe_com_component: systems
+        kubernetes.labels.hpe_com_app: systems
+        {{- else if .Values.odimra.deploymentType "RHOCP"}}
+        kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+        kubernetes.flat_labels.hpe_com/stack: process
+        kubernetes.flat_labels.hpe_com/component: systems
+        kubernetes.flat_labels.hpe_com/app : systems
       name: dapi-envars-fieldref
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}

--- a/odim-controller/helmcharts/systems/templates/deployment.yaml
+++ b/odim-controller/helmcharts/systems/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         kubernetes.flat_labels.hpe_com/stack: process
         kubernetes.flat_labels.hpe_com/component: systems
         kubernetes.flat_labels.hpe_com/app : systems
+        {{- end }}
       name: dapi-envars-fieldref
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}

--- a/odim-controller/helmcharts/systems/values.yaml
+++ b/odim-controller/helmcharts/systems/values.yaml
@@ -3,3 +3,4 @@ odimra:
   groupID:
   haDeploymentEnabled:
   systemsImageTag: "5.0"
+  deploymentType: "K8S"

--- a/odim-controller/helmcharts/task/templates/deployment.yaml
+++ b/odim-controller/helmcharts/task/templates/deployment.yaml
@@ -23,8 +23,8 @@ spec:
         kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
         kubernetes.flat_labels.hpe_com/stack: process
         kubernetes.flat_labels.hpe_com/component: task
-        kubernetes.flat_labels.hpe_com/app : task  
-        {{- end }}   
+        kubernetes.flat_labels.hpe_com/app : task
+        {{- end }}
       name: dapi-envars-fieldref
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}

--- a/odim-controller/helmcharts/task/templates/deployment.yaml
+++ b/odim-controller/helmcharts/task/templates/deployment.yaml
@@ -24,7 +24,17 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
-              app: task      
+              app: task 
+              {{- if eq .Values.odimra.deploymentType "K8S" }}
+              kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+              kubernetes.labels.hpe_com_stack: process
+              kubernetes.labels.hpe_com_component: task
+              kubernetes.labels.hpe_com_app: task
+              {{- else if .Values.odimra.deploymentType "RHOCP"}}
+              kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+              kubernetes.flat_labels.hpe_com/stack: process
+              kubernetes.flat_labels.hpe_com/component: task
+              kubernetes.flat_labels.hpe_com/app : task     
       hostname: task
       volumes:
         - name: odimra-config-vol

--- a/odim-controller/helmcharts/task/templates/deployment.yaml
+++ b/odim-controller/helmcharts/task/templates/deployment.yaml
@@ -14,6 +14,17 @@ spec:
     metadata:
       labels:
         app: task
+        {{- if eq .Values.odimra.deploymentType "K8S" }}
+        kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+        kubernetes.labels.hpe_com_stack: process
+        kubernetes.labels.hpe_com_component: task
+        kubernetes.labels.hpe_com_app: task
+        {{- else if .Values.odimra.deploymentType "RHOCP"}}
+        kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+        kubernetes.flat_labels.hpe_com/stack: process
+        kubernetes.flat_labels.hpe_com/component: task
+        kubernetes.flat_labels.hpe_com/app : task  
+        {{- end }}   
       name: dapi-envars-fieldref
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
@@ -25,17 +36,6 @@ spec:
           labelSelector:
             matchLabels:
               app: task 
-              {{- if eq .Values.odimra.deploymentType "K8S" }}
-              kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
-              kubernetes.labels.hpe_com_stack: process
-              kubernetes.labels.hpe_com_component: task
-              kubernetes.labels.hpe_com_app: task
-              {{- else if .Values.odimra.deploymentType "RHOCP"}}
-              kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
-              kubernetes.flat_labels.hpe_com/stack: process
-              kubernetes.flat_labels.hpe_com/component: task
-              kubernetes.flat_labels.hpe_com/app : task  
-              {{- end }}   
       hostname: task
       volumes:
         - name: odimra-config-vol

--- a/odim-controller/helmcharts/task/templates/deployment.yaml
+++ b/odim-controller/helmcharts/task/templates/deployment.yaml
@@ -34,7 +34,8 @@ spec:
               kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
               kubernetes.flat_labels.hpe_com/stack: process
               kubernetes.flat_labels.hpe_com/component: task
-              kubernetes.flat_labels.hpe_com/app : task     
+              kubernetes.flat_labels.hpe_com/app : task  
+              {{- end }}   
       hostname: task
       volumes:
         - name: odimra-config-vol

--- a/odim-controller/helmcharts/task/values.yaml
+++ b/odim-controller/helmcharts/task/values.yaml
@@ -3,3 +3,4 @@ odimra:
   groupID:
   haDeploymentEnabled:
   taskImageTag: "4.0"
+  deploymentType: "K8S"

--- a/odim-controller/helmcharts/telemetry/templates/deployment.yaml
+++ b/odim-controller/helmcharts/telemetry/templates/deployment.yaml
@@ -10,6 +10,16 @@ spec:
   selector:
     matchLabels:
       app: telemetry
+      {{- if eq .Values.odimra.deploymentType "K8S" }}
+      kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+      kubernetes.labels.hpe_com_stack: process
+      kubernetes.labels.hpe_com_component: telemetry
+      kubernetes.labels.hpe_com_app: telemetry
+      {{- else if .Values.odimra.deploymentType "RHOCP"}}
+      kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+      kubernetes.flat_labels.hpe_com/stack: process
+      kubernetes.flat_labels.hpe_com/component: telemetry
+      kubernetes.flat_labels.hpe_com/app : telemetry
   template:
     metadata:
       labels:

--- a/odim-controller/helmcharts/telemetry/templates/deployment.yaml
+++ b/odim-controller/helmcharts/telemetry/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       kubernetes.flat_labels.hpe_com/stack: process
       kubernetes.flat_labels.hpe_com/component: telemetry
       kubernetes.flat_labels.hpe_com/app : telemetry
+      {{- end }}
   template:
     metadata:
       labels:

--- a/odim-controller/helmcharts/telemetry/templates/deployment.yaml
+++ b/odim-controller/helmcharts/telemetry/templates/deployment.yaml
@@ -10,21 +10,21 @@ spec:
   selector:
     matchLabels:
       app: telemetry
-      {{- if eq .Values.odimra.deploymentType "K8S" }}
-      kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
-      kubernetes.labels.hpe_com_stack: process
-      kubernetes.labels.hpe_com_component: telemetry
-      kubernetes.labels.hpe_com_app: telemetry
-      {{- else if .Values.odimra.deploymentType "RHOCP"}}
-      kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
-      kubernetes.flat_labels.hpe_com/stack: process
-      kubernetes.flat_labels.hpe_com/component: telemetry
-      kubernetes.flat_labels.hpe_com/app : telemetry
-      {{- end }}
   template:
     metadata:
       labels:
         app: telemetry
+        {{- if eq .Values.odimra.deploymentType "K8S" }}
+        kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+        kubernetes.labels.hpe_com_stack: process
+        kubernetes.labels.hpe_com_component: telemetry
+        kubernetes.labels.hpe_com_app: telemetry
+        {{- else if .Values.odimra.deploymentType "RHOCP"}}
+        kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+        kubernetes.flat_labels.hpe_com/stack: process
+        kubernetes.flat_labels.hpe_com/component: telemetry
+        kubernetes.flat_labels.hpe_com/app : telemetry
+        {{- end }}
       name: dapi-envars-fieldref
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}

--- a/odim-controller/helmcharts/telemetry/values.yaml
+++ b/odim-controller/helmcharts/telemetry/values.yaml
@@ -3,3 +3,4 @@ odimra:
   groupID:
   haDeploymentEnabled:
   telemetryImageTag: "3.0"
+  deploymentType: "K8S"

--- a/odim-controller/helmcharts/update/templates/deployment.yaml
+++ b/odim-controller/helmcharts/update/templates/deployment.yaml
@@ -14,6 +14,17 @@ spec:
     metadata:
       labels:
         app: update
+        {{- if eq .Values.odimra.deploymentType "K8S" }}
+        kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+        kubernetes.labels.hpe_com_stack: process
+        kubernetes.labels.hpe_com_component: update
+        kubernetes.labels.hpe_com_app: update
+        {{- else if .Values.odimra.deploymentType "RHOCP"}}
+        kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+        kubernetes.flat_labels.hpe_com/stack: process
+        kubernetes.flat_labels.hpe_com/component: update
+        kubernetes.flat_labels.hpe_com/app : update  
+        {{- end }}  
       name: dapi-envars-fieldref
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
@@ -24,18 +35,7 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
-              app: update
-              {{- if eq .Values.odimra.deploymentType "K8S" }}
-              kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
-              kubernetes.labels.hpe_com_stack: process
-              kubernetes.labels.hpe_com_component: update
-              kubernetes.labels.hpe_com_app: update
-              {{- else if .Values.odimra.deploymentType "RHOCP"}}
-              kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
-              kubernetes.flat_labels.hpe_com/stack: process
-              kubernetes.flat_labels.hpe_com/component: update
-              kubernetes.flat_labels.hpe_com/app : update  
-              {{- end }}   
+              app: update 
       hostname: update
       volumes:
         - name: odimra-config-vol

--- a/odim-controller/helmcharts/update/templates/deployment.yaml
+++ b/odim-controller/helmcharts/update/templates/deployment.yaml
@@ -24,7 +24,17 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
-              app: update      
+              app: update
+              {{- if eq .Values.odimra.deploymentType "K8S" }}
+              kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+              kubernetes.labels.hpe_com_stack: process
+              kubernetes.labels.hpe_com_component: update
+              kubernetes.labels.hpe_com_app: update
+              {{- else if .Values.odimra.deploymentType "RHOCP"}}
+              kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+              kubernetes.flat_labels.hpe_com/stack: process
+              kubernetes.flat_labels.hpe_com/component: update
+              kubernetes.flat_labels.hpe_com/app : update     
       hostname: update
       volumes:
         - name: odimra-config-vol

--- a/odim-controller/helmcharts/update/templates/deployment.yaml
+++ b/odim-controller/helmcharts/update/templates/deployment.yaml
@@ -23,8 +23,8 @@ spec:
         kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
         kubernetes.flat_labels.hpe_com/stack: process
         kubernetes.flat_labels.hpe_com/component: update
-        kubernetes.flat_labels.hpe_com/app : update  
-        {{- end }}  
+        kubernetes.flat_labels.hpe_com/app : update
+        {{- end }}
       name: dapi-envars-fieldref
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}

--- a/odim-controller/helmcharts/update/templates/deployment.yaml
+++ b/odim-controller/helmcharts/update/templates/deployment.yaml
@@ -34,7 +34,8 @@ spec:
               kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
               kubernetes.flat_labels.hpe_com/stack: process
               kubernetes.flat_labels.hpe_com/component: update
-              kubernetes.flat_labels.hpe_com/app : update     
+              kubernetes.flat_labels.hpe_com/app : update  
+              {{- end }}   
       hostname: update
       volumes:
         - name: odimra-config-vol

--- a/odim-controller/helmcharts/update/values.yaml
+++ b/odim-controller/helmcharts/update/values.yaml
@@ -3,3 +3,4 @@ odimra:
   groupID:
   haDeploymentEnabled:
   updateImageTag: "4.0"
+  deploymentType: "K8S"

--- a/odim-controller/helmcharts/urplugin/urplugin/templates/deployment.yaml
+++ b/odim-controller/helmcharts/urplugin/urplugin/templates/deployment.yaml
@@ -23,7 +23,17 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
-              app: urplugin      
+              app: urplugin
+              {{- if eq .Values.odimra.deploymentType "K8S" }}
+              kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+              kubernetes.labels.hpe_com_stack: vendor-plugin
+              kubernetes.labels.hpe_com_component: urplugin
+              kubernetes.labels.hpe_com_app: urplugin
+              {{- else if .Values.odimra.deploymentType "RHOCP"}}
+              kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+              kubernetes.flat_labels.hpe_com/stack: vendor-plugin
+              kubernetes.flat_labels.hpe_com/component: urplugin
+              kubernetes.flat_labels.hpe_com/app : urplugin          
       hostname: urplugin
       volumes:
         - name: urplugin-config-vol

--- a/odim-controller/helmcharts/urplugin/urplugin/templates/deployment.yaml
+++ b/odim-controller/helmcharts/urplugin/urplugin/templates/deployment.yaml
@@ -23,8 +23,8 @@ spec:
         kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
         kubernetes.flat_labels.hpe_com/stack: vendor-plugin
         kubernetes.flat_labels.hpe_com/component: urplugin
-        kubernetes.flat_labels.hpe_com/app : urplugin      
-        {{- end }} 
+        kubernetes.flat_labels.hpe_com/app : urplugin
+        {{- end }}
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
     spec:

--- a/odim-controller/helmcharts/urplugin/urplugin/templates/deployment.yaml
+++ b/odim-controller/helmcharts/urplugin/urplugin/templates/deployment.yaml
@@ -14,6 +14,17 @@ spec:
     metadata:
       labels:
         app: urplugin
+        {{- if eq .Values.odimra.deploymentType "K8S" }}
+        kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
+        kubernetes.labels.hpe_com_stack: vendor-plugin
+        kubernetes.labels.hpe_com_component: urplugin
+        kubernetes.labels.hpe_com_app: urplugin
+        {{- else if .Values.odimra.deploymentType "RHOCP"}}
+        kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
+        kubernetes.flat_labels.hpe_com/stack: vendor-plugin
+        kubernetes.flat_labels.hpe_com/component: urplugin
+        kubernetes.flat_labels.hpe_com/app : urplugin      
+        {{- end }} 
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
     spec:
@@ -23,18 +34,7 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
-              app: urplugin
-              {{- if eq .Values.odimra.deploymentType "K8S" }}
-              kubernetes.labels.hpe_com_space: {{ .Values.odimra.namespace }}
-              kubernetes.labels.hpe_com_stack: vendor-plugin
-              kubernetes.labels.hpe_com_component: urplugin
-              kubernetes.labels.hpe_com_app: urplugin
-              {{- else if .Values.odimra.deploymentType "RHOCP"}}
-              kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
-              kubernetes.flat_labels.hpe_com/stack: vendor-plugin
-              kubernetes.flat_labels.hpe_com/component: urplugin
-              kubernetes.flat_labels.hpe_com/app : urplugin      
-              {{- end }}    
+              app: urplugin   
       hostname: urplugin
       volumes:
         - name: urplugin-config-vol

--- a/odim-controller/helmcharts/urplugin/urplugin/templates/deployment.yaml
+++ b/odim-controller/helmcharts/urplugin/urplugin/templates/deployment.yaml
@@ -33,7 +33,8 @@ spec:
               kubernetes.flat_labels.hpe_com/space: {{ .Values.odimra.namespace }} 
               kubernetes.flat_labels.hpe_com/stack: vendor-plugin
               kubernetes.flat_labels.hpe_com/component: urplugin
-              kubernetes.flat_labels.hpe_com/app : urplugin          
+              kubernetes.flat_labels.hpe_com/app : urplugin      
+              {{- end }}    
       hostname: urplugin
       volumes:
         - name: urplugin-config-vol

--- a/odim-controller/helmcharts/urplugin/urplugin/values.yaml
+++ b/odim-controller/helmcharts/urplugin/urplugin/values.yaml
@@ -2,6 +2,7 @@ odimra:
   namespace:
   groupID:
   haDeploymentEnabled:
+  deploymentType: "K8S"
 urplugin:
   imageTag: "3.2"
   urPluginRootServiceUUID:


### PR DESCRIPTION
-> New labels added to ODIM deployment pods which are needed for log extraction for CMS tools
-> Printing logs to the console instead of redirection, since fluentd fetches the logs from the console output

