### PR TITLE
Removing duplicate transactionID in svc-events 

### DIFF
--- a/svc-events/events/publishevttosubscriber.go
+++ b/svc-events/events/publishevttosubscriber.go
@@ -41,7 +41,6 @@ import (
 	"github.com/ODIM-Project/ODIM/lib-utilities/services"
 	"github.com/ODIM-Project/ODIM/svc-events/evmodel"
 	uuid "github.com/satori/go.uuid"
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -80,7 +79,6 @@ func (e *ExternalInterfaces) addFabric(ctx context.Context, message common.Messa
 //	bool: return false if any error occurred during execution, else returns true
 func (e *ExternalInterfaces) PublishEventsToDestination(ctx context.Context, data interface{}) bool {
 	eventUniqueID := uuid.NewV4().String()
-	logging = logging.WithFields(logrus.Fields{"transactionid": eventUniqueID})
 	if data == nil {
 		logging.Info("invalid input params")
 		return false

--- a/svc-events/events/publishevttosubscriber.go
+++ b/svc-events/events/publishevttosubscriber.go
@@ -41,6 +41,7 @@ import (
 	"github.com/ODIM-Project/ODIM/lib-utilities/services"
 	"github.com/ODIM-Project/ODIM/svc-events/evmodel"
 	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -79,6 +80,7 @@ func (e *ExternalInterfaces) addFabric(ctx context.Context, message common.Messa
 //	bool: return false if any error occurred during execution, else returns true
 func (e *ExternalInterfaces) PublishEventsToDestination(ctx context.Context, data interface{}) bool {
 	eventUniqueID := uuid.NewV4().String()
+	logging = logging.WithFields(logrus.Fields{"transaction_id": eventUniqueID})
 	if data == nil {
 		logging.Info("invalid input params")
 		return false


### PR DESCRIPTION
Changing code for Events service which is logging duplicate transactionId during events publishing.