### PR TITLE
svc folder readmes and plugin readmes - Italicized all references and links as per HPE style guide

### DIFF
--- a/plugin-dell/README.md
+++ b/plugin-dell/README.md
@@ -12,5 +12,5 @@ This guide provides a set of guidelines for developing API and EMB functions to 
 
 ## Dell plugin deployment instructions
 
-For deploying the Dell plugin and adding the plugin to the Resource Aggregator for ODIM framework, see the *Deploying the Dell plugin* section in the *[Resource Aggregator for Open Distributed Infrastructure Management™ Readme](https://github.com/ODIM-Project/ODIM/blob/development/README.md)*.
+For deploying the Dell plugin and adding the plugin to the Resource Aggregator for ODIM framework, see *Deploying the Dell plugin* section in *[Resource Aggregator for Open Distributed Infrastructure Management™ Readme](https://github.com/ODIM-Project/ODIM/blob/development/README.md)*.
 

--- a/plugin-lenovo/README.md
+++ b/plugin-lenovo/README.md
@@ -13,5 +13,5 @@ This guide provides a set of guidelines for developing API and EMB functions to 
 
 ## Lenovo plugin deployment instructions
 
-For deploying the Lenovo plugin and adding the plugin to the Resource Aggregator for ODIM framework, see the *Deploying the Lenovo plugin* section in the *[Resource Aggregator for Open Distributed Infrastructure Management™ Readme](https://github.com/ODIM-Project/ODIM/blob/development/README.md)*.
+For deploying the Lenovo plugin and adding the plugin to the Resource Aggregator for ODIM framework, see *Deploying the Lenovo plugin* section in *[Resource Aggregator for Open Distributed Infrastructure Management™ Readme](https://github.com/ODIM-Project/ODIM/blob/development/README.md)*.
 

--- a/plugin-redfish/README.md
+++ b/plugin-redfish/README.md
@@ -13,7 +13,7 @@ This guide provides a set of guidelines for developing API and EMB functions to 
 
 ## API accessibility
 
-The plugin layer uses JSON as the primary data format for communication. Standardizing on a well-known data-interchange format ensures consistency among plugins and simplifies the task for plugin developers. The API service uses [HATEOAS \(Hypermedia as the Engine of Application State\)](https://restfulapi.net/hateoas/) principles to link resources using the `href` key.
+The plugin layer uses JSON as the primary data format for communication. Standardizing on a well-known data-interchange format ensures consistency among plugins and simplifies the task for plugin developers. The API service uses *[HATEOAS \(Hypermedia as the Engine of Application State\)](https://restfulapi.net/hateoas/)* principles to link resources using the `href` key.
 
 The API service under the plugin layer can use basic authentication or token-based authentication for securing the platform. Token-based authentication is applicable to the authentication information flowing from the aggregator to the plugin where the aggregator is authenticated.
 

--- a/plugin-unmanaged-racks/README.md
+++ b/plugin-unmanaged-racks/README.md
@@ -34,7 +34,7 @@ Please be aware this plugin is still under development, and some features might 
 
 ## URP deployment instructions
 
-For deploying the Unmanaged Racks plugin and adding the plugin to the Resource Aggregator for ODIM framework, refer to the "Deploying the Unmanaged Rack Plugin" section in the [Resource Aggregator for Open Distributed Infrastructure Management™ Readme](https://github.com/ODIM-Project/ODIM/blob/main/README.md).
+For deploying the Unmanaged Racks plugin and adding the plugin to the Resource Aggregator for ODIM framework, see *Deploying the Unmanaged Rack Plugin* section in *[Resource Aggregator for Open Distributed Infrastructure Management™ Readme](https://github.com/ODIM-Project/ODIM/blob/main/README.md)*.
 
 
 

--- a/svc-aggregation/README.md
+++ b/svc-aggregation/README.md
@@ -1,3 +1,3 @@
 #  Aggregation Service
 
-For information on the supported `AggregationService` APIs, see [Resource aggregation and management](https://github.com/ODIM-Project/ODIM/blob/development/docs/README.md#resource-aggregation-and-management).
+For information on the supported `AggregationService` APIs, see *[Resource aggregation and management](https://github.com/ODIM-Project/ODIM/blob/development/docs/README.md#resource-aggregation-and-management)*.


### PR DESCRIPTION
Italicized all references and links in the svc folder readmes and plugin readmes as per HPE style guide